### PR TITLE
Harden JDK 8 application security and refresh dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,48 +8,63 @@
 
 ## 运行
 
-克隆代码：
+运行环境：
+
+- JDK 8（本项目会持续用 JDK 8 编译和运行）
+- Maven 3.9+
+- MySQL 8.x
+
+先确认实际使用的是 JDK 8：
 
 ```shell
-git clone https://github.com/jsnjfz/WebStack-Guns.git
+java -version
+mvn -version
 ```
 
-导入IDE，建议用IDEA打开项目目录，待maven下载完jar包
+构建已配置 Maven Enforcer，使用 JDK 9 或更高版本会直接失败，避免误把高版本 API 编译进项目。
 
-
-编辑配置：
-
-```
-application.yml
-```
-```
-上传文件路径，注意windows环境和linux环境：
-file-upload-path
-如需显示初始网站图标请把Webstack-Guns/src/main/webapp/static/tmp下的图片复制到上传文件路径
-```
-
-```
-...
-数据库连接，用户名密码：
-url
-username
-password
-...
-```
-
-新建数据库guns(utf8mb4)，导入数据：
+在本机 MySQL 中创建数据库并导入初始化数据：
 
 ```shell
-guns.sql
+mysql -h127.0.0.1 -P3306 -u你的账号 -p \
+  -e "CREATE DATABASE IF NOT EXISTS guns CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+mysql -h127.0.0.1 -P3306 -u你的账号 -p guns < sql/guns.sql
 ```
 
-maven打包或者IDE启动服务：
+如果是从旧版数据库升级，只需执行一次：
 
 ```shell
-$ java -jar Webstack-Guns-1.0.jar
+mysql -h127.0.0.1 -P3306 -u你的账号 -p guns < sql/security-upgrade.sql
 ```
 
-启动完成：http://127.0.0.1:8000
+数据库密码不再写死在 `application.yml`，通过环境变量传入：
+
+```shell
+export DB_URL='jdbc:mysql://127.0.0.1:3306/guns?autoReconnect=true&useUnicode=true&characterEncoding=utf8&zeroDateTimeBehavior=CONVERT_TO_NULL&useSSL=false&serverTimezone=Asia/Shanghai'
+export DB_USERNAME='你的账号'
+read -s DB_PASSWORD
+export DB_PASSWORD
+
+mvn clean verify
+java -jar target/Webstack-Guns-1.0.jar
+```
+
+启动完成后访问：<http://127.0.0.1:8000>
+
+本地未配置以下密钥时，应用会在每次启动时生成临时随机密钥；正式部署应显式配置，否则重启后旧 JWT 和 rememberMe Cookie 会失效：
+
+```shell
+export GUNS_JWT_SECRET="$(openssl rand -base64 64)"
+export GUNS_REMEMBER_ME_CIPHER_KEY="$(openssl rand -base64 16)"
+```
+
+其他可选配置：
+
+- `SERVER_ADDRESS`：默认 `127.0.0.1`；需要对外监听时显式设为 `0.0.0.0`
+- `SERVER_PORT`：默认 `8000`
+- `GUNS_FILE_UPLOAD_PATH`：默认使用系统临时目录下的独立上传目录
+- `GUNS_SECURE_COOKIE`：HTTPS 部署必须设为 `true`
+- `GUNS_SWAGGER_OPEN`、`GUNS_DRUID_MONITOR_OPEN`：默认关闭
 
 
 
@@ -83,7 +98,8 @@ $ java -jar Webstack-Guns-1.0.jar
 
 
 ## 声明
-如果在外网使用一定要升级shiro版本到最新，防止安全漏洞，因框架漏洞产生的服务器被攻击或渗透本人概不负责
+
+项目受 JDK 8 约束，采用 Spring Boot 2.7.x / Spring Framework 5.3.x / Shiro 1.13.x 的兼容线，并在应用层补充了登录限速、会话轮换、安全 Cookie、CSRF、富文本净化、上传校验和安全响应头。外网部署仍应放在 HTTPS 反向代理之后，并在网关层增加统一限速和访问日志告警。
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security notes
+
+## 兼容边界
+
+本项目必须运行在 JDK 8，因此采用 Spring Boot 2.7.18、Spring Framework 5.3.39 和 Apache Shiro 1.13.0。Shiro 2.x 需要 Java 11，Spring Framework 6.x 需要 Java 17，不能在当前约束下直接升级。
+
+2026-07-26 使用 OSV `querybatch` 对 Maven 完整依赖树复扫：
+
+- 升级前：41 个受影响组件、208 个唯一公告。
+- 升级后：11 个受影响组件、22 个唯一公告（其中 1 个组件/1 个公告仅在 test scope）。
+- Tomcat 9.0.120、Jackson 2.18.9、MySQL Connector 8.4.0、Log4j 2.25.5、Druid 1.2.28、Fastjson `1.2.83_noneautotype` 等本轮升级目标未再命中 OSV。
+
+扫描仍会按版本命中下列公告。它们没有被静默忽略，处置依据如下。
+
+| 组件 / 公告 | 本项目处置 |
+| --- | --- |
+| MyBatis-Plus `GHSA-32qq-m9fh-f74w` | 公告只影响 `TenantPlugin` 的租户 ID 拼接；项目未配置或调用该插件。 |
+| Spring Boot `GHSA-rc42-6c7j-7h5r` | 项目不依赖 Spring Security，也未使用 `EndpointRequest.to()`。 |
+| Spring Boot `GHSA-wwpq-f5c3-7hvx` | 已显式设置 `server.servlet.session.persistent=false`，不持久化容器 Session。 |
+| Spring Web/Context `GHSA-4gc7-5j7h-4qph`、`GHSA-4wp7-92pw-q264` | 项目未使用 `DataBinder.setDisallowedFields`，不存在公告所述大小写绕过配置。 |
+| Spring Web `GHSA-4wrc-f8pq-fpqp` | 项目未对不可信输入调用 Java 原生反序列化或 Spring `SerializationUtils.deserialize`。 |
+| Spring MVC `GHSA-4773-3jfm-qmx3` | 视图为固定 classpath Beetl 模板，未启用 Java 脚本模板引擎。 |
+| Spring MVC `GHSA-6hcq-hmm3-jj3c` | 项目没有 SSE endpoint。 |
+| Spring MVC `GHSA-6p4f-wcwh-5vvm` | 未从文件系统配置 Spring 静态资源 location；当前运行环境也不是 Windows。 |
+| Spring MVC `GHSA-cx7f-g6mp-7hqm`、`GHSA-g5vr-rgqm-vf78` | 未使用 `RouterFunctions` / WebMvc.fn；运行容器为已升级的 Tomcat。 |
+| Spring MVC `GHSA-r936-gwx5-v52f` | 使用 Tomcat 9.0.120 默认 URI 规范化保护，未关闭相关保护。 |
+| Spring MVC `GHSA-w3c8-7r8f-9jp8` | 没有 `@RequestBody byte[]` 控制器参数。 |
+| Spring MVC `GHSA-wg35-8jpf-2xv3` | 未启用 Spring resource chain 和 encoded-resource resolver 缓存组合。 |
+| Spring Core `GHSA-jmp9-x22r-554x` | 未使用 Spring Security `@EnableMethodSecurity`；授权由 Shiro 和项目注解完成。 |
+| Shiro `GHSA-c4qc-4q9p-m9q9` | 不存在账号也执行同成本 PBKDF2；单实例按 IP+账号限制 5 次失败/5 分钟。 |
+| Shiro `GHSA-fcvm-3cpj-f9qx` | 登录前注销旧认证 Session，成功后创建新 Session；HTTP 验收确认 Shiro 认证 Session ID 已轮换。 |
+| Shiro `GHSA-x96m-rh44-vgv8` | 未使用 `DefaultLdapRealm`，项目使用数据库 Realm。 |
+| Shiro `GHSA-c244-p6m5-vqj6` | 静态资源本来就是公开内容，没有依赖 Shiro 对静态文件做细粒度保护。 |
+| Shiro `GHSA-c6r4-qjmw-cvj2` | Session/rememberMe Cookie 已设置 HttpOnly、SameSite；HTTPS 部署必须配置 `GUNS_SECURE_COOKIE=true`。 |
+| Beetl `GHSA-m69h-4frq-vwq7` | 公告详情针对 Beetl 3.15 的动态 `render`；项目使用固定 classpath 模板，不接受用户模板源码。通知富文本另经 OWASP 白名单净化。 |
+| AssertJ `GHSA-rqfh-9r24-8c9r` | 仅 test scope，项目测试未调用不可信 XML 的 `isXmlEqualTo` / `xmlPrettyFormat`。 |
+
+## 已实施的应用层保护
+
+- 旧 MD5 口令成功登录后迁移到 PBKDF2-HMAC-SHA256（210,000 次迭代、随机盐）。
+- JWT 和 rememberMe 固定公开密钥已移除；生产环境通过环境变量提供随机密钥。
+- REST token 每次请求检查签名、过期时间以及用户当前是否仍存在且启用。
+- CSRF token 覆盖后台写请求；旧的可变更 GET 路径也纳入校验。
+- 通知富文本使用 OWASP HTML Sanitizer 白名单，编辑页输出使用 OWASP Encoder。
+- 图片上传限制为 5 MB、限制像素、解码并重新编码；图片读取使用严格 UUID 文件名和规范化路径。
+- Swagger 和 Druid 监控默认关闭；服务默认只监听 `127.0.0.1`。
+- 浏览器响应包含 CSP、frame、MIME sniffing、referrer 和 permissions 安全头。
+
+移除 JDK 8 约束后，应优先升级到仍在公开支持期的 Spring 和 Shiro 主版本，并重新执行完整依赖扫描与运行验收。

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.1.RELEASE</version>
+        <version>2.7.18</version>
     </parent>
 
     <groupId>com.jsnjfz.manage</groupId>
@@ -22,15 +22,104 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <shiro.version>2.0.5</shiro.version>
-        <kaptcha.version>2.3.2</kaptcha.version>
-        <ehcache.version>3.3.1</ehcache.version>
+        <spring-framework.version>5.3.39</spring-framework.version>
+        <tomcat.version>9.0.120</tomcat.version>
+        <jackson-bom.version>2.18.9</jackson-bom.version>
+        <snakeyaml.version>2.2</snakeyaml.version>
+        <log4j2.version>2.25.5</log4j2.version>
+        <shiro.version>1.13.0</shiro.version>
+        <kaptcha.version>2.3.3</kaptcha.version>
+        <ehcache.version>2.10.9.2</ehcache.version>
         <beetl.version>2.9.10</beetl.version>
-        <swagger.version>2.9.2</swagger.version>
-        <ehcache.core.version>2.6.11</ehcache.core.version>
-        <mysql-connector-java.version>8.0.28</mysql-connector-java.version>
-        <jwt.version>0.12.0</jwt.version>
+        <swagger.version>3.0.0</swagger.version>
+        <mysql.version>8.4.0</mysql.version>
+        <mybatis-plus.version>2.3.3</mybatis-plus.version>
+        <mybatis.version>3.5.19</mybatis.version>
+        <mybatis-spring.version>2.1.2</mybatis-spring.version>
+        <hutool.version>5.8.47</hutool.version>
+        <druid.version>1.2.28</druid.version>
+        <fastjson.version>1.2.83_noneautotype</fastjson.version>
+        <jwt.version>0.13.0</jwt.version>
+        <poi.version>5.5.1</poi.version>
+        <okhttp.version>4.12.0</okhttp.version>
+        <classgraph.version>4.8.184</classgraph.version>
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
+        <json-path.version>2.9.0</json-path.version>
+        <xmlunit2.version>2.11.0</xmlunit2.version>
+        <html-sanitizer.version>20260313.1</html-sanitizer.version>
+        <owasp-encoder.version>1.3.1</owasp-encoder.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.baomidou</groupId>
+                <artifactId>mybatis-plus</artifactId>
+                <version>${mybatis-plus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.baomidou</groupId>
+                <artifactId>mybatis-plus-core</artifactId>
+                <version>${mybatis-plus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.baomidou</groupId>
+                <artifactId>mybatis-plus-support</artifactId>
+                <version>${mybatis-plus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.baomidou</groupId>
+                <artifactId>mybatis-plus-generate</artifactId>
+                <version>${mybatis-plus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.baomidou</groupId>
+                <artifactId>mybatis-plus-boot-starter</artifactId>
+                <version>${mybatis-plus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mybatis</groupId>
+                <artifactId>mybatis</artifactId>
+                <version>${mybatis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mybatis</groupId>
+                <artifactId>mybatis-spring</artifactId>
+                <version>${mybatis-spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>cn.hutool</groupId>
+                <artifactId>hutool-core</artifactId>
+                <version>${hutool.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba</groupId>
+                <artifactId>druid</artifactId>
+                <version>${druid.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba</groupId>
+                <artifactId>fastjson</artifactId>
+                <version>${fastjson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.classgraph</groupId>
+                <artifactId>classgraph</artifactId>
+                <version>${classgraph.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>${commons-beanutils.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
 
@@ -46,47 +135,79 @@
             <groupId>cn.stylefeng.roses</groupId>
             <artifactId>kernel-core</artifactId>
             <version>1.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>${mysql.version}</version>
         </dependency>
 
         <!--spring boot依赖-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-cache</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <optional>true</optional>
-        </dependency>
-
         <!--shiro依赖和缓存-->
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
-            <version>2.0.1.RELEASE</version>
+            <version>${shiro.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
@@ -97,63 +218,79 @@
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-spring</artifactId>
-            <version>1.10.0</version>
+            <version>${shiro.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-ehcache</artifactId>
-            <version>1.10.0</version>
+            <version>${shiro.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>ehcache-core</artifactId>
+                    <groupId>net.sf.ehcache</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.ehcache</groupId>
+            <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache</artifactId>
-            <version>3.3.1</version>
+            <version>${ehcache.version}</version>
         </dependency>
 
         <!--验证码-->
         <dependency>
-            <groupId>com.github.penggle</groupId>
+            <groupId>pro.fessional</groupId>
             <artifactId>kaptcha</artifactId>
-            <version>2.3.2</version>
+            <version>${kaptcha.version}</version>
         </dependency>
 
         <!--beetl模板引擎-->
         <dependency>
             <groupId>com.ibeetl</groupId>
             <artifactId>beetl</artifactId>
-            <version>2.9.3</version>
+            <version>${beetl.version}</version>
         </dependency>
 
         <!--swagger-->
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
-            <version>2.9.2</version>
+            <version>${swagger.version}</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.9.2</version>
+            <version>${swagger.version}</version>
         </dependency>
 
         <!--jwt token-->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
-            <version>0.9.0</version>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jwt.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- excel操作 -->
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>4.1.1</version>
+            <version>${poi.version}</version>
         </dependency>
 
         <dependency>
@@ -165,9 +302,20 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.2</version>
+            <version>${okhttp.version}</version>
         </dependency>
 
+        <!--富文本白名单净化和安全输出编码-->
+        <dependency>
+            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+            <artifactId>owasp-java-html-sanitizer</artifactId>
+            <version>${html-sanitizer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+            <version>${owasp-encoder.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -190,8 +338,29 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.6.3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-jdk-8</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[1.8,1.9)</version>
+                                    <message>本项目必须使用 JDK 8 构建。</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -217,10 +386,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
+                <version>2.22.2</version>
             </plugin>
         </plugins>
         <resources>

--- a/sql/guns.sql
+++ b/sql/guns.sql
@@ -637,7 +637,7 @@ CREATE TABLE `sys_user`  (
   `id` int(11) NOT NULL AUTO_INCREMENT COMMENT '主键id',
   `avatar` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT '头像',
   `account` varchar(45) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT '账号',
-  `password` varchar(45) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT '密码',
+  `password` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT '密码摘要',
   `salt` varchar(45) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT 'md5密码盐',
   `name` varchar(45) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT '名字',
   `birthday` datetime(0) NULL DEFAULT NULL COMMENT '生日',

--- a/sql/security-upgrade.sql
+++ b/sql/security-upgrade.sql
@@ -1,0 +1,5 @@
+-- 已有数据库升级到本版本时执行一次。
+-- 新导入 sql/guns.sql 的数据库无需重复执行。
+
+ALTER TABLE `sys_user`
+    MODIFY COLUMN `password` varchar(255) NULL DEFAULT NULL COMMENT '密码摘要';

--- a/src/main/java/com/jsnjfz/manage/WebstackGunsApplication.java
+++ b/src/main/java/com/jsnjfz/manage/WebstackGunsApplication.java
@@ -16,6 +16,7 @@
 package com.jsnjfz.manage;
 
 import cn.stylefeng.roses.core.config.WebAutoConfiguration;
+import cn.stylefeng.roses.core.config.MybaitsPlusAutoConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -27,7 +28,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * @author stylefeng
  * @Date 2017/5/21 12:06
  */
-@SpringBootApplication(exclude = WebAutoConfiguration.class)
+@SpringBootApplication(exclude = {WebAutoConfiguration.class, MybaitsPlusAutoConfiguration.class})
 public class WebstackGunsApplication {
 
     private final static Logger logger = LoggerFactory.getLogger(WebstackGunsApplication.class);

--- a/src/main/java/com/jsnjfz/manage/config/SwaggerConfig.java
+++ b/src/main/java/com/jsnjfz/manage/config/SwaggerConfig.java
@@ -23,6 +23,7 @@ import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -35,7 +36,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
  */
 @Configuration
 @EnableSwagger2
-@ConditionalOnProperty(prefix = "jsnjfz", name = "swagger-open", havingValue = "true")
+@ConditionalOnProperty(prefix = "guns", name = "swagger-open", havingValue = "true")
 public class SwaggerConfig {
 
     @Bean
@@ -54,7 +55,7 @@ public class SwaggerConfig {
                 .title("Doc")
                 .description("Api文档")
                 .termsOfServiceUrl("")
-                .contact("")
+                .contact(new Contact("", "", ""))
                 .version("2.0")
                 .build();
     }

--- a/src/main/java/com/jsnjfz/manage/config/properties/GunsProperties.java
+++ b/src/main/java/com/jsnjfz/manage/config/properties/GunsProperties.java
@@ -45,6 +45,14 @@ public class GunsProperties {
 
     private Boolean springSessionOpen = false;
 
+    private Boolean secureCookie = false;
+
+    private Boolean druidMonitorOpen = false;
+
+    private String jwtSecret;
+
+    private String rememberMeCipherKey;
+
     /**
      * session 失效时间（默认为30分钟 单位：秒）
      */
@@ -58,20 +66,19 @@ public class GunsProperties {
     public String getFileUploadPath() {
         //如果没有写文件上传路径,保存到临时目录
         if (ToolUtil.isEmpty(fileUploadPath)) {
-            return getTempPath();
-        } else {
-            //判断有没有结尾符,没有得加上
-            if (!fileUploadPath.endsWith(File.separator)) {
-                fileUploadPath = fileUploadPath + File.separator;
-            }
-            //判断目录存不存在,不存在得加上
-            if (!haveCreatePath) {
-                File file = new File(fileUploadPath);
-                file.mkdirs();
-                haveCreatePath = true;
-            }
-            return fileUploadPath;
+            fileUploadPath = new File(getTempPath(), "webstack-guns-uploads").getAbsolutePath();
         }
+        //判断有没有结尾符,没有得加上
+        if (!fileUploadPath.endsWith(File.separator)) {
+            fileUploadPath = fileUploadPath + File.separator;
+        }
+        //判断目录存不存在,不存在得加上
+        if (!haveCreatePath) {
+            File file = new File(fileUploadPath);
+            file.mkdirs();
+            haveCreatePath = true;
+        }
+        return fileUploadPath;
     }
 
     public void setFileUploadPath(String fileUploadPath) {
@@ -116,5 +123,37 @@ public class GunsProperties {
 
     public void setSessionValidationInterval(Integer sessionValidationInterval) {
         this.sessionValidationInterval = sessionValidationInterval;
+    }
+
+    public Boolean getSecureCookie() {
+        return secureCookie;
+    }
+
+    public void setSecureCookie(Boolean secureCookie) {
+        this.secureCookie = secureCookie;
+    }
+
+    public Boolean getDruidMonitorOpen() {
+        return druidMonitorOpen;
+    }
+
+    public void setDruidMonitorOpen(Boolean druidMonitorOpen) {
+        this.druidMonitorOpen = druidMonitorOpen;
+    }
+
+    public String getJwtSecret() {
+        return jwtSecret;
+    }
+
+    public void setJwtSecret(String jwtSecret) {
+        this.jwtSecret = jwtSecret;
+    }
+
+    public String getRememberMeCipherKey() {
+        return rememberMeCipherKey;
+    }
+
+    public void setRememberMeCipherKey(String rememberMeCipherKey) {
+        this.rememberMeCipherKey = rememberMeCipherKey;
     }
 }

--- a/src/main/java/com/jsnjfz/manage/config/web/ShiroConfig.java
+++ b/src/main/java/com/jsnjfz/manage/config/web/ShiroConfig.java
@@ -17,13 +17,10 @@ package com.jsnjfz.manage.config.web;
 
 import com.jsnjfz.manage.config.properties.GunsProperties;
 import com.jsnjfz.manage.core.interceptor.GunsUserFilter;
-import com.jsnjfz.manage.core.shiro.ShiroDbRealm;
-import com.jsnjfz.manage.config.properties.GunsProperties;
-import com.jsnjfz.manage.core.interceptor.GunsUserFilter;
+import com.jsnjfz.manage.core.security.PasswordService;
 import com.jsnjfz.manage.core.shiro.ShiroDbRealm;
 import org.apache.shiro.cache.CacheManager;
 import org.apache.shiro.cache.ehcache.EhCacheManager;
-import org.apache.shiro.codec.Base64;
 import org.apache.shiro.session.mgt.SessionManager;
 import org.apache.shiro.spring.LifecycleBeanPostProcessor;
 import org.apache.shiro.spring.security.interceptor.AuthorizationAttributeSourceAdvisor;
@@ -40,11 +37,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.Filter;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.security.SecureRandom;
 
 /**
  * shiro权限管理的配置
@@ -55,13 +55,18 @@ import java.util.Map;
 @Configuration
 public class ShiroConfig {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShiroConfig.class);
+
     /**
      * 安全管理器
      */
     @Bean
-    public DefaultWebSecurityManager securityManager(CookieRememberMeManager rememberMeManager, CacheManager cacheShiroManager, SessionManager sessionManager) {
+    public DefaultWebSecurityManager securityManager(CookieRememberMeManager rememberMeManager,
+                                                     CacheManager cacheShiroManager,
+                                                     SessionManager sessionManager,
+                                                     ShiroDbRealm shiroDbRealm) {
         DefaultWebSecurityManager securityManager = new DefaultWebSecurityManager();
-        securityManager.setRealm(this.shiroDbRealm());
+        securityManager.setRealm(shiroDbRealm);
         securityManager.setCacheManager(cacheShiroManager);
         securityManager.setRememberMeManager(rememberMeManager);
         securityManager.setSessionManager(sessionManager);
@@ -92,6 +97,8 @@ public class ShiroConfig {
         Cookie cookie = new SimpleCookie(ShiroHttpSession.DEFAULT_SESSION_ID_NAME);
         cookie.setName("shiroCookie");
         cookie.setHttpOnly(true);
+        cookie.setSecure(gunsProperties.getSecureCookie());
+        cookie.setSameSite(Cookie.SameSiteOptions.LAX);
         sessionManager.setSessionIdCookie(cookie);
         return sessionManager;
     }
@@ -110,28 +117,50 @@ public class ShiroConfig {
      * 项目自定义的Realm
      */
     @Bean
-    public ShiroDbRealm shiroDbRealm() {
-        return new ShiroDbRealm();
+    public ShiroDbRealm shiroDbRealm(PasswordService passwordService) {
+        return new ShiroDbRealm(passwordService);
     }
 
     /**
      * rememberMe管理器, cipherKey生成见{@code Base64Test.java}
      */
     @Bean
-    public CookieRememberMeManager rememberMeManager(SimpleCookie rememberMeCookie) {
+    public CookieRememberMeManager rememberMeManager(SimpleCookie rememberMeCookie,
+                                                     GunsProperties gunsProperties) {
         CookieRememberMeManager manager = new CookieRememberMeManager();
-        manager.setCipherKey(Base64.decode("Z3VucwAAAAAAAAAAAAAAAA=="));
+        manager.setCipherKey(resolveRememberMeKey(gunsProperties.getRememberMeCipherKey()));
         manager.setCookie(rememberMeCookie);
         return manager;
+    }
+
+    private byte[] resolveRememberMeKey(String configuredKey) {
+        byte[] key;
+        if (configuredKey == null || configuredKey.trim().isEmpty()) {
+            key = new byte[16];
+            new SecureRandom().nextBytes(key);
+            LOGGER.warn("未配置 guns.remember-me-cipher-key，本次启动已生成临时 rememberMe 密钥");
+        } else {
+            try {
+                key = java.util.Base64.getDecoder().decode(configuredKey.trim());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("guns.remember-me-cipher-key 必须是 Base64 字符串", e);
+            }
+        }
+        if (key.length != 16 && key.length != 24 && key.length != 32) {
+            throw new IllegalArgumentException("guns.remember-me-cipher-key 解码后必须是 16、24 或 32 字节");
+        }
+        return key;
     }
 
     /**
      * 记住密码Cookie
      */
     @Bean
-    public SimpleCookie rememberMeCookie() {
+    public SimpleCookie rememberMeCookie(GunsProperties gunsProperties) {
         SimpleCookie simpleCookie = new SimpleCookie("rememberMe");
         simpleCookie.setHttpOnly(true);
+        simpleCookie.setSecure(gunsProperties.getSecureCookie());
+        simpleCookie.setSameSite(Cookie.SameSiteOptions.LAX);
         simpleCookie.setMaxAge(7 * 24 * 60 * 60);//7天
         return simpleCookie;
     }

--- a/src/main/java/com/jsnjfz/manage/config/web/WebConfig.java
+++ b/src/main/java/com/jsnjfz/manage/config/web/WebConfig.java
@@ -19,10 +19,10 @@ import com.jsnjfz.manage.config.properties.GunsProperties;
 import com.jsnjfz.manage.core.common.controller.GunsErrorView;
 import com.jsnjfz.manage.core.interceptor.RestApiInteceptor;
 import com.jsnjfz.manage.core.listener.ConfigListener;
-import com.jsnjfz.manage.config.properties.GunsProperties;
-import com.jsnjfz.manage.core.common.controller.GunsErrorView;
-import com.jsnjfz.manage.core.interceptor.RestApiInteceptor;
-import com.jsnjfz.manage.core.listener.ConfigListener;
+import com.jsnjfz.manage.core.util.JwtTokenUtil;
+import com.jsnjfz.manage.core.security.CsrfFilter;
+import com.jsnjfz.manage.core.security.SecurityHeadersFilter;
+import com.jsnjfz.manage.modular.system.dao.UserMapper;
 import cn.stylefeng.roses.core.xss.XssFilter;
 import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.support.http.StatViewServlet;
@@ -40,6 +40,7 @@ import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.web.context.request.RequestContextListener;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -60,6 +61,12 @@ public class WebConfig implements WebMvcConfigurer {
     @Autowired
     private GunsProperties gunsProperties;
 
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Autowired
+    private UserMapper userMapper;
+
     /**
      * 增加swagger的支持
      */
@@ -76,7 +83,8 @@ public class WebConfig implements WebMvcConfigurer {
      */
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new RestApiInteceptor()).addPathPatterns("/gunsApi/**");
+        registry.addInterceptor(new RestApiInteceptor(jwtTokenUtil, userMapper))
+                .addPathPatterns("/gunsApi/**");
     }
 
     /**
@@ -91,6 +99,8 @@ public class WebConfig implements WebMvcConfigurer {
      * druidServlet注册
      */
     @Bean
+    @org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(
+            prefix = "guns", name = "druid-monitor-open", havingValue = "true")
     public ServletRegistrationBean druidServletRegistration() {
         ServletRegistrationBean registration = new ServletRegistrationBean(new StatViewServlet());
         registration.addUrlMappings("/druid/*");
@@ -101,6 +111,8 @@ public class WebConfig implements WebMvcConfigurer {
      * druid监控 配置URI拦截策略
      */
     @Bean
+    @org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(
+            prefix = "guns", name = "druid-monitor-open", havingValue = "true")
     public FilterRegistrationBean druidStatFilter() {
         FilterRegistrationBean filterRegistrationBean = new FilterRegistrationBean(new WebStatFilter());
         //添加过滤规则.
@@ -117,11 +129,15 @@ public class WebConfig implements WebMvcConfigurer {
      * druid数据库连接池监控
      */
     @Bean
+    @org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(
+            prefix = "guns", name = "druid-monitor-open", havingValue = "true")
     public DruidStatInterceptor druidStatInterceptor() {
         return new DruidStatInterceptor();
     }
 
     @Bean
+    @org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(
+            prefix = "guns", name = "druid-monitor-open", havingValue = "true")
     public JdkRegexpMethodPointcut druidStatPointcut() {
         JdkRegexpMethodPointcut druidStatPointcut = new JdkRegexpMethodPointcut();
         String patterns = "com.jsnjfz.manage.modular.*.service.*";
@@ -134,6 +150,8 @@ public class WebConfig implements WebMvcConfigurer {
      * druid数据库连接池监控
      */
     @Bean
+    @org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(
+            prefix = "guns", name = "druid-monitor-open", havingValue = "true")
     public BeanTypeAutoProxyCreator beanTypeAutoProxyCreator() {
         BeanTypeAutoProxyCreator beanTypeAutoProxyCreator = new BeanTypeAutoProxyCreator();
         beanTypeAutoProxyCreator.setTargetBeanType(DruidDataSource.class);
@@ -147,6 +165,8 @@ public class WebConfig implements WebMvcConfigurer {
      * @return
      */
     @Bean
+    @org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(
+            prefix = "guns", name = "druid-monitor-open", havingValue = "true")
     public Advisor druidStatAdvisor() {
         return new DefaultPointcutAdvisor(druidStatPointcut(), druidStatInterceptor());
     }
@@ -160,6 +180,25 @@ public class WebConfig implements WebMvcConfigurer {
         xssFilter.setUrlExclusion(Arrays.asList("/notice/update", "/notice/add"));
         FilterRegistrationBean registration = new FilterRegistrationBean(xssFilter);
         registration.addUrlPatterns("/*");
+        registration.setOrder(30);
+        return registration;
+    }
+
+    @Bean
+    public FilterRegistrationBean<SecurityHeadersFilter> securityHeadersFilterRegistration() {
+        FilterRegistrationBean<SecurityHeadersFilter> registration =
+                new FilterRegistrationBean<>(new SecurityHeadersFilter());
+        registration.addUrlPatterns("/*");
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
+
+    @Bean
+    public FilterRegistrationBean<CsrfFilter> csrfFilterRegistration() {
+        FilterRegistrationBean<CsrfFilter> registration =
+                new FilterRegistrationBean<>(new CsrfFilter(gunsProperties));
+        registration.addUrlPatterns("/*");
+        registration.setOrder(20);
         return registration;
     }
 

--- a/src/main/java/com/jsnjfz/manage/core/aop/GlobalExceptionHandler.java
+++ b/src/main/java/com/jsnjfz/manage/core/aop/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ package com.jsnjfz.manage.core.aop;
 
 import com.jsnjfz.manage.core.common.exception.BizExceptionEnum;
 import com.jsnjfz.manage.core.common.exception.InvalidKaptchaException;
+import com.jsnjfz.manage.core.common.exception.InvalidUploadException;
 import com.jsnjfz.manage.core.log.LogManager;
 import com.jsnjfz.manage.core.log.factory.LogTaskFactory;
 import com.jsnjfz.manage.core.shiro.ShiroKit;
@@ -59,10 +60,19 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ResponseBody
     public ErrorResponseData bussiness(ServiceException e) {
-        LogManager.me().executeLog(LogTaskFactory.exceptionLog(ShiroKit.getUser().getId(), e));
+        if (ShiroKit.getUser() != null) {
+            LogManager.me().executeLog(LogTaskFactory.exceptionLog(ShiroKit.getUser().getId(), e));
+        }
         getRequest().setAttribute("tip", e.getMessage());
         log.error("业务异常:", e);
         return new ErrorResponseData(e.getCode(), e.getMessage());
+    }
+
+    @ExceptionHandler(InvalidUploadException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ErrorResponseData invalidUpload(InvalidUploadException e) {
+        return new ErrorResponseData(BizExceptionEnum.UPLOAD_ERROR.getCode(), e.getMessage());
     }
 
     /**
@@ -130,7 +140,9 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ResponseBody
     public ErrorResponseData notFount(RuntimeException e) {
-        LogManager.me().executeLog(LogTaskFactory.exceptionLog(ShiroKit.getUser().getId(), e));
+        if (ShiroKit.getUser() != null) {
+            LogManager.me().executeLog(LogTaskFactory.exceptionLog(ShiroKit.getUser().getId(), e));
+        }
         getRequest().setAttribute("tip", "服务器未知运行时异常");
         log.error("运行时异常:", e);
         return new ErrorResponseData(BizExceptionEnum.SERVER_ERROR.getCode(), BizExceptionEnum.SERVER_ERROR.getMessage());

--- a/src/main/java/com/jsnjfz/manage/core/common/constant/JwtConstants.java
+++ b/src/main/java/com/jsnjfz/manage/core/common/constant/JwtConstants.java
@@ -25,8 +25,6 @@ public interface JwtConstants {
 
     String AUTH_HEADER = "Authorization";
 
-    String SECRET = "defaultSecret";
-
     Long EXPIRATION = 604800L;
 
     String AUTH_PATH = "/gunsApi/auth";

--- a/src/main/java/com/jsnjfz/manage/core/common/constant/factory/MutiStrFactory.java
+++ b/src/main/java/com/jsnjfz/manage/core/common/constant/factory/MutiStrFactory.java
@@ -72,7 +72,7 @@ public class MutiStrFactory {
             return new ArrayList<>();
         } else {
             ArrayList<Map<String, String>> results = new ArrayList<>();
-            String[] items = StrUtil.split(StrUtil.removeSuffix(mutiString, ITEM_SPLIT), ITEM_SPLIT);
+            List<String> items = StrUtil.split(StrUtil.removeSuffix(mutiString, ITEM_SPLIT), ITEM_SPLIT);
             for (String item : items) {
                 String[] attrs = item.split(ATTR_SPLIT);
                 HashMap<String, String> itemMap = new HashMap<>();

--- a/src/main/java/com/jsnjfz/manage/core/common/exception/BizExceptionEnum.java
+++ b/src/main/java/com/jsnjfz/manage/core/common/exception/BizExceptionEnum.java
@@ -37,7 +37,7 @@ public enum BizExceptionEnum implements AbstractBaseExceptionEnum {
      */
     FILE_READING_ERROR(400, "FILE_READING_ERROR!"),
     FILE_NOT_FOUND(400, "FILE_NOT_FOUND!"),
-    UPLOAD_ERROR(500, "上传图片出错"),
+    UPLOAD_ERROR(400, "上传图片出错"),
 
     /**
      * 权限和数据问题

--- a/src/main/java/com/jsnjfz/manage/core/common/exception/InvalidUploadException.java
+++ b/src/main/java/com/jsnjfz/manage/core/common/exception/InvalidUploadException.java
@@ -1,0 +1,11 @@
+package com.jsnjfz.manage.core.common.exception;
+
+/**
+ * 上传内容不是受支持的安全图片。
+ */
+public class InvalidUploadException extends RuntimeException {
+
+    public InvalidUploadException() {
+        super("上传图片格式或内容不合法");
+    }
+}

--- a/src/main/java/com/jsnjfz/manage/core/interceptor/RestApiInteceptor.java
+++ b/src/main/java/com/jsnjfz/manage/core/interceptor/RestApiInteceptor.java
@@ -17,10 +17,10 @@ package com.jsnjfz.manage.core.interceptor;
 
 import com.jsnjfz.manage.core.common.constant.JwtConstants;
 import com.jsnjfz.manage.core.common.exception.BizExceptionEnum;
+import com.jsnjfz.manage.core.common.constant.state.ManagerStatus;
 import com.jsnjfz.manage.core.util.JwtTokenUtil;
-import com.jsnjfz.manage.core.common.constant.JwtConstants;
-import com.jsnjfz.manage.core.common.exception.BizExceptionEnum;
-import com.jsnjfz.manage.core.util.JwtTokenUtil;
+import com.jsnjfz.manage.modular.system.dao.UserMapper;
+import com.jsnjfz.manage.modular.system.model.User;
 import cn.stylefeng.roses.core.reqres.response.ErrorResponseData;
 import cn.stylefeng.roses.core.util.RenderUtil;
 import io.jsonwebtoken.JwtException;
@@ -37,6 +37,14 @@ import javax.servlet.http.HttpServletResponse;
  * @Date 2018/7/20 23:11
  */
 public class RestApiInteceptor extends HandlerInterceptorAdapter {
+
+    private final JwtTokenUtil jwtTokenUtil;
+    private final UserMapper userMapper;
+
+    public RestApiInteceptor(JwtTokenUtil jwtTokenUtil, UserMapper userMapper) {
+        this.jwtTokenUtil = jwtTokenUtil;
+        this.userMapper = userMapper;
+    }
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
@@ -57,18 +65,30 @@ public class RestApiInteceptor extends HandlerInterceptorAdapter {
 
             //验证token是否过期,包含了验证jwt是否正确
             try {
-                boolean flag = JwtTokenUtil.isTokenExpired(authToken);
+                boolean flag = jwtTokenUtil.isTokenExpired(authToken);
                 if (flag) {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                     RenderUtil.renderJson(response, new ErrorResponseData(BizExceptionEnum.TOKEN_EXPIRED.getCode(), BizExceptionEnum.TOKEN_EXPIRED.getMessage()));
                     return false;
                 }
-            } catch (JwtException e) {
+                String userId = jwtTokenUtil.getUsernameFromToken(authToken);
+                User user = userMapper.selectById(Integer.valueOf(userId));
+                if (user == null || user.getStatus() == null
+                        || user.getStatus() != ManagerStatus.OK.getCode()) {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    RenderUtil.renderJson(response, new ErrorResponseData(
+                            BizExceptionEnum.TOKEN_ERROR.getCode(), BizExceptionEnum.TOKEN_ERROR.getMessage()));
+                    return false;
+                }
+            } catch (JwtException | IllegalArgumentException e) {
                 //有异常就是token解析失败
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 RenderUtil.renderJson(response, new ErrorResponseData(BizExceptionEnum.TOKEN_ERROR.getCode(), BizExceptionEnum.TOKEN_ERROR.getMessage()));
                 return false;
             }
         } else {
             //header没有带Bearer字段
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             RenderUtil.renderJson(response, new ErrorResponseData(BizExceptionEnum.TOKEN_ERROR.getCode(), BizExceptionEnum.TOKEN_ERROR.getMessage()));
             return false;
         }

--- a/src/main/java/com/jsnjfz/manage/core/security/CsrfFilter.java
+++ b/src/main/java/com/jsnjfz/manage/core/security/CsrfFilter.java
@@ -1,0 +1,136 @@
+package com.jsnjfz.manage.core.security;
+
+import com.jsnjfz.manage.config.properties.GunsProperties;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.regex.Pattern;
+
+/**
+ * 基于 Session 的 CSRF 防护，兼容现有 jQuery/WebUploader 页面。
+ */
+public class CsrfFilter extends OncePerRequestFilter {
+
+    public static final String COOKIE_NAME = "XSRF-TOKEN";
+    public static final String HEADER_NAME = "X-CSRF-TOKEN";
+    public static final String REQUEST_ATTRIBUTE = "csrfToken";
+    private static final String SESSION_ATTRIBUTE = CsrfFilter.class.getName() + ".TOKEN";
+    private static final Pattern LEGACY_GET_MUTATION = Pattern.compile(
+            ".*/(add|update|delete|edit|remove|reset|freeze|unfreeze|setRole|setAuthority|changePwd|upload|delLog|delLoginLog)$");
+
+    private final SecureRandom secureRandom = new SecureRandom();
+    private final GunsProperties gunsProperties;
+
+    public CsrfFilter(GunsProperties gunsProperties) {
+        this.gunsProperties = gunsProperties;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (!contextPath.isEmpty() && uri.startsWith(contextPath)) {
+            uri = uri.substring(contextPath.length());
+        }
+        return uri.startsWith("/static/")
+                || uri.equals("/favicon.ico")
+                || uri.startsWith("/gunsApi/");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        HttpSession session = request.getSession(false);
+        String token = session == null ? null : (String) session.getAttribute(SESSION_ATTRIBUTE);
+
+        if (token == null && shouldCreateToken(request)) {
+            session = request.getSession(true);
+            token = createToken();
+            session.setAttribute(SESSION_ATTRIBUTE, token);
+        }
+
+        if (token != null) {
+            request.setAttribute(REQUEST_ATTRIBUTE, token);
+            if (!token.equals(readCookie(request, COOKIE_NAME))) {
+                addTokenCookie(request, response, token);
+            }
+        }
+
+        if (requiresValidation(request) && !matches(token, submittedToken(request))) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write("{\"code\":403,\"message\":\"CSRF token invalid\"}");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean shouldCreateToken(HttpServletRequest request) {
+        String method = request.getMethod();
+        return "GET".equals(method) || "HEAD".equals(method);
+    }
+
+    private boolean requiresValidation(HttpServletRequest request) {
+        String method = request.getMethod();
+        if (!"GET".equals(method) && !"HEAD".equals(method) && !"OPTIONS".equals(method)) {
+            return true;
+        }
+        return LEGACY_GET_MUTATION.matcher(request.getRequestURI()).matches();
+    }
+
+    private String submittedToken(HttpServletRequest request) {
+        String token = request.getHeader(HEADER_NAME);
+        return token == null || token.isEmpty() ? request.getParameter("_csrf") : token;
+    }
+
+    private boolean matches(String expected, String submitted) {
+        if (expected == null || submitted == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(
+                expected.getBytes(StandardCharsets.US_ASCII),
+                submitted.getBytes(StandardCharsets.US_ASCII));
+    }
+
+    private String createToken() {
+        byte[] bytes = new byte[32];
+        secureRandom.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String readCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    private void addTokenCookie(HttpServletRequest request, HttpServletResponse response, String token) {
+        String path = request.getContextPath().isEmpty() ? "/" : request.getContextPath();
+        StringBuilder cookie = new StringBuilder(COOKIE_NAME)
+                .append('=').append(token)
+                .append("; Path=").append(path)
+                .append("; SameSite=Lax");
+        if (Boolean.TRUE.equals(gunsProperties.getSecureCookie())) {
+            cookie.append("; Secure");
+        }
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+}

--- a/src/main/java/com/jsnjfz/manage/core/security/LoginAttemptService.java
+++ b/src/main/java/com/jsnjfz/manage/core/security/LoginAttemptService.java
@@ -1,0 +1,80 @@
+package com.jsnjfz.manage.core.security;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * 单实例登录失败限速。生产多实例部署时仍应在网关层增加统一限速。
+ */
+@Component
+public class LoginAttemptService {
+
+    private static final int MAX_FAILURES = 5;
+    private static final long WINDOW_MILLIS = 5 * 60 * 1000L;
+    private static final int MAX_ENTRIES = 10000;
+
+    private final Map<String, AttemptWindow> attempts = new ConcurrentHashMap<>();
+    private final AtomicLong operations = new AtomicLong();
+
+    public boolean isAllowed(String remoteAddress, String username) {
+        cleanupIfNeeded();
+        AttemptWindow window = attempts.get(key(remoteAddress, username));
+        return window == null || window.expired() || window.failures < MAX_FAILURES;
+    }
+
+    public void recordFailure(String remoteAddress, String username) {
+        String key = key(remoteAddress, username);
+        attempts.compute(key, (ignored, current) -> {
+            if (current == null || current.expired()) {
+                return new AttemptWindow(1, System.currentTimeMillis() + WINDOW_MILLIS);
+            }
+            return new AttemptWindow(current.failures + 1, current.expiresAt);
+        });
+        cleanupIfNeeded();
+    }
+
+    public void reset(String remoteAddress, String username) {
+        attempts.remove(key(remoteAddress, username));
+    }
+
+    private String key(String remoteAddress, String username) {
+        String address = remoteAddress == null ? "unknown" : remoteAddress;
+        String account = username == null ? "" : username.trim().toLowerCase(Locale.ROOT);
+        if (account.length() > 128) {
+            account = account.substring(0, 128);
+        }
+        return address + '\n' + account;
+    }
+
+    private void cleanupIfNeeded() {
+        if (operations.incrementAndGet() % 256 != 0 && attempts.size() <= MAX_ENTRIES) {
+            return;
+        }
+        for (Map.Entry<String, AttemptWindow> entry : attempts.entrySet()) {
+            if (entry.getValue().expired()) {
+                attempts.remove(entry.getKey(), entry.getValue());
+            }
+        }
+        if (attempts.size() > MAX_ENTRIES) {
+            attempts.clear();
+        }
+    }
+
+    private static final class AttemptWindow {
+        private final int failures;
+        private final long expiresAt;
+
+        private AttemptWindow(int failures, long expiresAt) {
+            this.failures = failures;
+            this.expiresAt = expiresAt;
+        }
+
+        private boolean expired() {
+            return System.currentTimeMillis() >= expiresAt;
+        }
+    }
+}

--- a/src/main/java/com/jsnjfz/manage/core/security/PasswordCredentialsMatcher.java
+++ b/src/main/java/com/jsnjfz/manage/core/security/PasswordCredentialsMatcher.java
@@ -1,0 +1,40 @@
+package com.jsnjfz.manage.core.security;
+
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.credential.CredentialsMatcher;
+import org.apache.shiro.authc.credential.HashedCredentialsMatcher;
+
+/**
+ * 同时接受 PBKDF2 新格式和存量 MD5，存量密码会在成功登录后迁移。
+ */
+public class PasswordCredentialsMatcher implements CredentialsMatcher {
+
+    private final PasswordService passwordService;
+    private final HashedCredentialsMatcher legacyMatcher;
+
+    public PasswordCredentialsMatcher(PasswordService passwordService) {
+        this.passwordService = passwordService;
+        this.legacyMatcher = new HashedCredentialsMatcher();
+        this.legacyMatcher.setHashAlgorithmName("MD5");
+        this.legacyMatcher.setHashIterations(1024);
+    }
+
+    @Override
+    public boolean doCredentialsMatch(AuthenticationToken token, AuthenticationInfo info) {
+        String stored = String.valueOf(info.getCredentials());
+        if (!passwordService.isModern(stored)) {
+            boolean matched = legacyMatcher.doCredentialsMatch(token, info);
+            passwordService.burnTime(rawPassword(token));
+            return matched;
+        }
+        return passwordService.matches(rawPassword(token), stored, null);
+    }
+
+    private String rawPassword(AuthenticationToken token) {
+        Object submitted = token.getCredentials();
+        return submitted instanceof char[]
+                ? new String((char[]) submitted)
+                : String.valueOf(submitted);
+    }
+}

--- a/src/main/java/com/jsnjfz/manage/core/security/PasswordService.java
+++ b/src/main/java/com/jsnjfz/manage/core/security/PasswordService.java
@@ -1,0 +1,114 @@
+package com.jsnjfz.manage.core.security;
+
+import com.jsnjfz.manage.core.shiro.ShiroKit;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * 新密码使用 PBKDF2；旧的带盐 MD5 仅用于登录时兼容和渐进迁移。
+ */
+@Component
+public class PasswordService {
+
+    private static final String PREFIX = "pbkdf2";
+    private static final int ITERATIONS = 210000;
+    private static final int SALT_BYTES = 16;
+    private static final int HASH_BITS = 256;
+    private static final int MAX_PASSWORD_LENGTH = 1024;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+    private final String dummyHash = encode("timing-mitigation-only");
+
+    public String encode(String rawPassword) {
+        validatePassword(rawPassword);
+        byte[] salt = new byte[SALT_BYTES];
+        secureRandom.nextBytes(salt);
+        byte[] hash = derive(rawPassword.toCharArray(), salt, ITERATIONS);
+        return PREFIX + "$" + ITERATIONS + "$"
+                + Base64.getEncoder().withoutPadding().encodeToString(salt) + "$"
+                + Base64.getEncoder().withoutPadding().encodeToString(hash);
+    }
+
+    public boolean matches(String rawPassword, String encodedPassword, String legacySalt) {
+        if (rawPassword == null || encodedPassword == null || rawPassword.length() > MAX_PASSWORD_LENGTH) {
+            return false;
+        }
+        if (!isModern(encodedPassword)) {
+            return legacySalt != null && MessageDigest.isEqual(
+                    ShiroKit.md5(rawPassword, legacySalt).getBytes(StandardCharsets.US_ASCII),
+                    encodedPassword.getBytes(StandardCharsets.US_ASCII));
+        }
+        try {
+            String[] parts = encodedPassword.split("\\$");
+            if (parts.length != 4) {
+                return false;
+            }
+            int iterations = Integer.parseInt(parts[1]);
+            byte[] salt = Base64.getDecoder().decode(parts[2]);
+            byte[] expected = Base64.getDecoder().decode(parts[3]);
+            if (iterations < 100000 || iterations > 1000000
+                    || salt.length < 16 || salt.length > 64
+                    || expected.length < 16 || expected.length > 64) {
+                return false;
+            }
+            byte[] actual = derive(rawPassword.toCharArray(), salt, iterations);
+            return MessageDigest.isEqual(actual, expected);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * 用户不存在时也执行一次同成本的 PBKDF2，降低账号枚举的时序差异。
+     * 旧 MD5 账号在迁移前也执行同一次计算，避免暴露其存储格式。
+     */
+    public boolean matchesOrBurn(String rawPassword, String encodedPassword, String legacySalt) {
+        if (encodedPassword == null) {
+            burnTime(rawPassword);
+            return false;
+        }
+        boolean matched = matches(rawPassword, encodedPassword, legacySalt);
+        if (!isModern(encodedPassword)) {
+            burnTime(rawPassword);
+        }
+        return matched;
+    }
+
+    public void burnTime(String rawPassword) {
+        String candidate = rawPassword == null ? "" : rawPassword;
+        matches(candidate, dummyHash, null);
+    }
+
+    public boolean isModern(String encodedPassword) {
+        return encodedPassword != null && encodedPassword.startsWith(PREFIX + "$");
+    }
+
+    private byte[] derive(char[] password, byte[] salt, int iterations) {
+        PBEKeySpec spec = new PBEKeySpec(password, salt, iterations, HASH_BITS);
+        try {
+            return SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+                    .generateSecret(spec)
+                    .getEncoded();
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("当前 JDK 不支持 PBKDF2WithHmacSHA256", e);
+        } finally {
+            spec.clearPassword();
+        }
+    }
+
+    private void validatePassword(String rawPassword) {
+        if (rawPassword == null || rawPassword.isEmpty()) {
+            throw new IllegalArgumentException("密码不能为空");
+        }
+        if (rawPassword.length() > MAX_PASSWORD_LENGTH) {
+            throw new IllegalArgumentException("密码长度不能超过 " + MAX_PASSWORD_LENGTH + " 个字符");
+        }
+    }
+}

--- a/src/main/java/com/jsnjfz/manage/core/security/RichTextSanitizer.java
+++ b/src/main/java/com/jsnjfz/manage/core/security/RichTextSanitizer.java
@@ -1,0 +1,23 @@
+package com.jsnjfz.manage.core.security;
+
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
+import org.springframework.stereotype.Component;
+
+/**
+ * 通知富文本白名单。保留编辑器常用格式，移除脚本、事件属性和危险 URL。
+ */
+@Component
+public class RichTextSanitizer {
+
+    private final PolicyFactory policy = Sanitizers.FORMATTING
+            .and(Sanitizers.BLOCKS)
+            .and(Sanitizers.STYLES)
+            .and(Sanitizers.LINKS)
+            .and(Sanitizers.TABLES)
+            .and(Sanitizers.IMAGES);
+
+    public String sanitize(String html) {
+        return html == null ? "" : policy.sanitize(html);
+    }
+}

--- a/src/main/java/com/jsnjfz/manage/core/security/SecurityHeadersFilter.java
+++ b/src/main/java/com/jsnjfz/manage/core/security/SecurityHeadersFilter.java
@@ -1,0 +1,30 @@
+package com.jsnjfz.manage.core.security;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * 浏览器端基础安全响应头。
+ */
+public class SecurityHeadersFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        response.setHeader("X-Content-Type-Options", "nosniff");
+        response.setHeader("X-Frame-Options", "SAMEORIGIN");
+        response.setHeader("Referrer-Policy", "same-origin");
+        response.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+        response.setHeader("Content-Security-Policy",
+                "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+                        + "style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; "
+                        + "font-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; "
+                        + "object-src 'none'; base-uri 'self'; form-action 'self'");
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/jsnjfz/manage/core/shiro/ShiroDbRealm.java
+++ b/src/main/java/com/jsnjfz/manage/core/shiro/ShiroDbRealm.java
@@ -15,8 +15,8 @@
  */
 package com.jsnjfz.manage.core.shiro;
 
-import com.jsnjfz.manage.core.shiro.service.UserAuthService;
-import com.jsnjfz.manage.modular.system.model.User;
+import com.jsnjfz.manage.core.security.PasswordCredentialsMatcher;
+import com.jsnjfz.manage.core.security.PasswordService;
 import com.jsnjfz.manage.core.shiro.service.UserAuthService;
 import com.jsnjfz.manage.core.shiro.service.impl.UserAuthServiceServiceImpl;
 import com.jsnjfz.manage.modular.system.model.User;
@@ -25,8 +25,6 @@ import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.UsernamePasswordToken;
-import org.apache.shiro.authc.credential.CredentialsMatcher;
-import org.apache.shiro.authc.credential.HashedCredentialsMatcher;
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
 import org.apache.shiro.realm.AuthorizingRealm;
@@ -38,6 +36,13 @@ import java.util.Set;
 
 public class ShiroDbRealm extends AuthorizingRealm {
 
+    private final PasswordService passwordService;
+
+    public ShiroDbRealm(PasswordService passwordService) {
+        this.passwordService = passwordService;
+        super.setCredentialsMatcher(new PasswordCredentialsMatcher(passwordService));
+    }
+
     /**
      * 登录认证
      */
@@ -47,6 +52,10 @@ public class ShiroDbRealm extends AuthorizingRealm {
         UserAuthService shiroFactory = UserAuthServiceServiceImpl.me();
         UsernamePasswordToken token = (UsernamePasswordToken) authcToken;
         User user = shiroFactory.user(token.getUsername());
+        if (user == null) {
+            passwordService.burnTime(new String(token.getPassword()));
+            return null;
+        }
         ShiroUser shiroUser = shiroFactory.shiroUser(user);
         return shiroFactory.info(shiroUser, user, super.getName());
     }
@@ -82,14 +91,4 @@ public class ShiroDbRealm extends AuthorizingRealm {
         return info;
     }
 
-    /**
-     * 设置认证加密方式
-     */
-    @Override
-    public void setCredentialsMatcher(CredentialsMatcher credentialsMatcher) {
-        HashedCredentialsMatcher md5CredentialsMatcher = new HashedCredentialsMatcher();
-        md5CredentialsMatcher.setHashAlgorithmName(ShiroKit.hashAlgorithmName);
-        md5CredentialsMatcher.setHashIterations(ShiroKit.hashIterations);
-        super.setCredentialsMatcher(md5CredentialsMatcher);
-    }
 }

--- a/src/main/java/com/jsnjfz/manage/core/util/JwtTokenUtil.java
+++ b/src/main/java/com/jsnjfz/manage/core/util/JwtTokenUtil.java
@@ -15,13 +15,23 @@
  */
 package com.jsnjfz.manage.core.util;
 
+import com.jsnjfz.manage.config.properties.GunsProperties;
 import com.jsnjfz.manage.core.common.constant.JwtConstants;
-import cn.stylefeng.roses.core.util.ToolUtil;
 import io.jsonwebtoken.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * <p>jwt token工具类</p>
@@ -39,58 +49,89 @@ import java.util.Map;
  * @author fengshuonan
  * @Date 2017/8/25 10:59
  */
+@Component
 public class JwtTokenUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JwtTokenUtil.class);
+
+    private static final int MIN_SECRET_BYTES = 64;
+
+    private final SecretKey signingKey;
+
+    public JwtTokenUtil(GunsProperties gunsProperties) {
+        this.signingKey = createSigningKey(gunsProperties.getJwtSecret());
+    }
+
+    private SecretKey createSigningKey(String configuredSecret) {
+        byte[] keyBytes;
+        if (configuredSecret == null || configuredSecret.trim().isEmpty()) {
+            keyBytes = new byte[MIN_SECRET_BYTES];
+            new SecureRandom().nextBytes(keyBytes);
+            LOGGER.warn("未配置 guns.jwt-secret，本次启动已生成临时 JWT 密钥；应用重启后旧 token 将失效");
+        } else {
+            try {
+                keyBytes = Base64.getDecoder().decode(configuredSecret.trim());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("guns.jwt-secret 必须是 Base64 字符串", e);
+            }
+            if (keyBytes.length < MIN_SECRET_BYTES) {
+                throw new IllegalArgumentException("guns.jwt-secret 解码后至少需要 64 字节");
+            }
+        }
+        return new SecretKeySpec(keyBytes, "HmacSHA512");
+    }
 
     /**
      * 获取用户名从token中
      */
-    public static String getUsernameFromToken(String token) {
+    public String getUsernameFromToken(String token) {
         return getClaimFromToken(token).getSubject();
     }
 
     /**
      * 获取jwt发布时间
      */
-    public static Date getIssuedAtDateFromToken(String token) {
+    public Date getIssuedAtDateFromToken(String token) {
         return getClaimFromToken(token).getIssuedAt();
     }
 
     /**
      * 获取jwt失效时间
      */
-    public static Date getExpirationDateFromToken(String token) {
+    public Date getExpirationDateFromToken(String token) {
         return getClaimFromToken(token).getExpiration();
     }
 
     /**
      * 获取jwt接收者
      */
-    public static String getAudienceFromToken(String token) {
+    public Set<String> getAudienceFromToken(String token) {
         return getClaimFromToken(token).getAudience();
     }
 
     /**
      * 获取私有的jwt claim
      */
-    public static String getPrivateClaimFromToken(String token, String key) {
+    public String getPrivateClaimFromToken(String token, String key) {
         return getClaimFromToken(token).get(key).toString();
     }
 
     /**
      * 获取jwt的payload部分
      */
-    public static Claims getClaimFromToken(String token) {
+    public Claims getClaimFromToken(String token) {
         return Jwts.parser()
-                .setSigningKey(JwtConstants.SECRET)
-                .parseClaimsJws(token)
-                .getBody();
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
     }
 
     /**
      * 解析token是否正确,不正确会报异常<br>
      */
-    public static void parseToken(String token) throws JwtException {
-        Jwts.parser().setSigningKey(JwtConstants.SECRET).parseClaimsJws(token).getBody();
+    public void parseToken(String token) throws JwtException {
+        Jwts.parser().verifyWith(signingKey).build().parseSignedClaims(token);
     }
 
     /**
@@ -99,7 +140,7 @@ public class JwtTokenUtil {
      *  true:过期   false:没过期
      * </pre>
      */
-    public static Boolean isTokenExpired(String token) {
+    public Boolean isTokenExpired(String token) {
         try {
             final Date expiration = getExpirationDateFromToken(token);
             return expiration.before(new Date());
@@ -111,7 +152,7 @@ public class JwtTokenUtil {
     /**
      * 生成token(通过用户名和签名时候用的随机数)
      */
-    public static String generateToken(String userId) {
+    public String generateToken(String userId) {
         Map<String, Object> claims = new HashMap<>();
         return doGenerateToken(claims, userId);
     }
@@ -119,7 +160,7 @@ public class JwtTokenUtil {
     /**
      * 生成token
      */
-    private static String doGenerateToken(Map<String, Object> claims, String subject) {
+    private String doGenerateToken(Map<String, Object> claims, String subject) {
         final Date createdDate = new Date();
         final Date expirationDate = new Date(createdDate.getTime() + JwtConstants.EXPIRATION * 1000);
 
@@ -128,14 +169,8 @@ public class JwtTokenUtil {
                 .setSubject(subject)
                 .setIssuedAt(createdDate)
                 .setExpiration(expirationDate)
-                .signWith(SignatureAlgorithm.HS512, JwtConstants.SECRET)
+                .setId(UUID.randomUUID().toString())
+                .signWith(signingKey, SignatureAlgorithm.HS512)
                 .compact();
-    }
-
-    /**
-     * 获取混淆MD5签名用的随机字符串
-     */
-    public static String getRandomKey() {
-        return ToolUtil.getRandomString(6);
     }
 }

--- a/src/main/java/com/jsnjfz/manage/modular/api/ApiController.java
+++ b/src/main/java/com/jsnjfz/manage/modular/api/ApiController.java
@@ -15,29 +15,23 @@
  */
 package com.jsnjfz.manage.modular.api;
 
-import com.jsnjfz.manage.core.shiro.ShiroKit;
-import com.jsnjfz.manage.core.shiro.ShiroUser;
 import com.jsnjfz.manage.core.util.JwtTokenUtil;
-import com.jsnjfz.manage.modular.system.dao.UserMapper;
-import com.jsnjfz.manage.modular.system.model.User;
-import com.jsnjfz.manage.core.shiro.ShiroKit;
-import com.jsnjfz.manage.core.shiro.ShiroUser;
-import com.jsnjfz.manage.core.util.JwtTokenUtil;
+import com.jsnjfz.manage.core.security.PasswordService;
+import com.jsnjfz.manage.core.security.LoginAttemptService;
+import com.jsnjfz.manage.core.common.constant.state.ManagerStatus;
 import com.jsnjfz.manage.modular.system.dao.UserMapper;
 import com.jsnjfz.manage.modular.system.model.User;
 import cn.stylefeng.roses.core.base.controller.BaseController;
 import cn.stylefeng.roses.core.reqres.response.ErrorResponseData;
-import org.apache.shiro.authc.SimpleAuthenticationInfo;
-import org.apache.shiro.authc.UsernamePasswordToken;
-import org.apache.shiro.authc.credential.HashedCredentialsMatcher;
-import org.apache.shiro.crypto.hash.Md5Hash;
-import org.apache.shiro.util.ByteSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 
 /**
@@ -53,38 +47,53 @@ public class ApiController extends BaseController {
     @Autowired
     private UserMapper userMapper;
 
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Autowired
+    private PasswordService passwordService;
+
+    @Autowired
+    private LoginAttemptService loginAttemptService;
+
     /**
      * api登录接口，通过账号密码获取token
      */
-    @RequestMapping("/auth")
+    @RequestMapping(value = "/auth", method = RequestMethod.POST)
     public Object auth(@RequestParam("username") String username,
-                       @RequestParam("password") String password) {
-
-        //封装请求账号密码为shiro可验证的token
-        UsernamePasswordToken usernamePasswordToken = new UsernamePasswordToken(username, password.toCharArray());
+                       @RequestParam("password") String password,
+                       HttpServletRequest request) {
 
         //获取数据库中的账号密码，准备比对
+        String remoteAddress = request.getRemoteAddr();
+        if (!loginAttemptService.isAllowed(remoteAddress, username)) {
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                    .body(new ErrorResponseData(429, "登录失败次数过多，请稍后再试"));
+        }
         User user = userMapper.getByAccount(username);
-
-        String credentials = user.getPassword();
-        String salt = user.getSalt();
-        ByteSource credentialsSalt = new Md5Hash(salt);
-        SimpleAuthenticationInfo simpleAuthenticationInfo = new SimpleAuthenticationInfo(
-                new ShiroUser(), credentials, credentialsSalt, "");
-
-        //校验用户账号密码
-        HashedCredentialsMatcher md5CredentialsMatcher = new HashedCredentialsMatcher();
-        md5CredentialsMatcher.setHashAlgorithmName(ShiroKit.hashAlgorithmName);
-        md5CredentialsMatcher.setHashIterations(ShiroKit.hashIterations);
-        boolean passwordTrueFlag = md5CredentialsMatcher.doCredentialsMatch(
-                usernamePasswordToken, simpleAuthenticationInfo);
+        boolean credentialsMatch = passwordService.matchesOrBurn(
+                password,
+                user == null ? null : user.getPassword(),
+                user == null ? null : user.getSalt());
+        boolean passwordTrueFlag = credentialsMatch
+                && user != null
+                && user.getStatus() != null
+                && ManagerStatus.OK.getCode() == user.getStatus();
 
         if (passwordTrueFlag) {
+            loginAttemptService.reset(remoteAddress, username);
+            if (!passwordService.isModern(user.getPassword())) {
+                user.setPassword(passwordService.encode(password));
+                user.setSalt("");
+                user.updateById();
+            }
             HashMap<String, Object> result = new HashMap<>();
-            result.put("token", JwtTokenUtil.generateToken(String.valueOf(user.getId())));
+            result.put("token", jwtTokenUtil.generateToken(String.valueOf(user.getId())));
             return result;
         } else {
-            return new ErrorResponseData(500, "账号密码错误！");
+            loginAttemptService.recordFailure(remoteAddress, username);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ErrorResponseData(401, "账号密码错误！"));
         }
     }
 
@@ -97,4 +106,3 @@ public class ApiController extends BaseController {
     }
 
 }
-

--- a/src/main/java/com/jsnjfz/manage/modular/system/controller/KaptchaController.java
+++ b/src/main/java/com/jsnjfz/manage/modular/system/controller/KaptchaController.java
@@ -15,7 +15,6 @@
  */
 package com.jsnjfz.manage.modular.system.controller;
 
-import cn.stylefeng.roses.core.util.FileUtil;
 import com.google.code.kaptcha.Constants;
 import com.google.code.kaptcha.Producer;
 import com.jsnjfz.manage.config.properties.GunsProperties;
@@ -30,7 +29,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * 验证码生成
@@ -41,6 +45,9 @@ import java.io.IOException;
 @Controller
 @RequestMapping("/kaptcha")
 public class KaptchaController {
+
+    private static final Pattern PICTURE_NAME = Pattern.compile(
+            "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\.(jpg|png|gif)$");
 
     @Autowired
     private GunsProperties gunsProperties;
@@ -113,16 +120,25 @@ public class KaptchaController {
      */
     @RequestMapping("/{pictureId}")
     public void renderPicture(@PathVariable("pictureId") String pictureId, HttpServletResponse response) {
-        String path = gunsProperties.getFileUploadPath() + pictureId;
+        if (pictureId == null || !PICTURE_NAME.matcher(pictureId).matches()) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
         try {
-            byte[] bytes = FileUtil.toByteArray(path);
-            response.getOutputStream().write(bytes);
+            Path root = new File(gunsProperties.getFileUploadPath()).toPath().toAbsolutePath().normalize();
+            Path picture = root.resolve(pictureId).normalize();
+            if (!picture.startsWith(root) || !Files.isRegularFile(picture)) {
+                response.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            }
+            String suffix = pictureId.substring(pictureId.lastIndexOf('.') + 1).toLowerCase(Locale.ROOT);
+            response.setContentType("jpg".equals(suffix) ? "image/jpeg" : "image/" + suffix);
+            response.setHeader("X-Content-Type-Options", "nosniff");
+            response.setHeader("Cache-Control", "private, max-age=86400");
+            Files.copy(picture, response.getOutputStream());
         } catch (Exception e) {
-            //如果找不到图片就返回一个默认图片
-            try {
-                response.sendRedirect("/static/img/github.png");
-            } catch (IOException e1) {
-                e1.printStackTrace();
+            if (!response.isCommitted()) {
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             }
         }
     }

--- a/src/main/java/com/jsnjfz/manage/modular/system/controller/LoginController.java
+++ b/src/main/java/com/jsnjfz/manage/modular/system/controller/LoginController.java
@@ -26,20 +26,23 @@ import com.jsnjfz.manage.core.shiro.ShiroKit;
 import com.jsnjfz.manage.core.shiro.ShiroUser;
 import com.jsnjfz.manage.core.util.ApiMenuFilter;
 import com.jsnjfz.manage.core.util.KaptchaUtil;
-import com.jsnjfz.manage.modular.system.model.User;
-import com.jsnjfz.manage.modular.system.service.IMenuService;
-import com.jsnjfz.manage.modular.system.service.IUserService;
+import com.jsnjfz.manage.core.security.PasswordService;
+import com.jsnjfz.manage.core.security.LoginAttemptService;
 import cn.stylefeng.roses.core.base.controller.BaseController;
 import cn.stylefeng.roses.core.util.ToolUtil;
 import com.google.code.kaptcha.Constants;
 import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.ExcessiveAttemptsException;
 import org.apache.shiro.subject.Subject;
+import org.apache.shiro.session.Session;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 import static cn.stylefeng.roses.core.util.HttpContext.getIp;
@@ -58,6 +61,12 @@ public class LoginController extends BaseController {
 
     @Autowired
     private IUserService userService;
+
+    @Autowired
+    private PasswordService passwordService;
+
+    @Autowired
+    private LoginAttemptService loginAttemptService;
 
     /**
      * 跳转到主页
@@ -102,11 +111,15 @@ public class LoginController extends BaseController {
      * 点击登录执行的动作
      */
     @RequestMapping(value = "/login", method = RequestMethod.POST)
-    public String loginVali() {
+    public String loginVali(HttpServletRequest request) {
 
         String username = super.getPara("username").trim();
         String password = super.getPara("password").trim();
         String remember = super.getPara("remember");
+        String remoteAddress = request.getRemoteAddr();
+        if (!loginAttemptService.isAllowed(remoteAddress, username)) {
+            throw new ExcessiveAttemptsException("登录失败次数过多，请稍后再试");
+        }
 
         //验证验证码是否正确
         if (KaptchaUtil.getKaptchaOnOff()) {
@@ -126,15 +139,32 @@ public class LoginController extends BaseController {
             token.setRememberMe(false);
         }
 
-        currentUser.login(token);
+        Session existingSession = currentUser.getSession(false);
+        if (existingSession != null) {
+            currentUser.logout();
+        }
+        try {
+            currentUser.login(token);
+        } catch (AuthenticationException e) {
+            loginAttemptService.recordFailure(remoteAddress, username);
+            throw e;
+        }
+        loginAttemptService.reset(remoteAddress, username);
 
         ShiroUser shiroUser = ShiroKit.getUser();
-        super.getSession().setAttribute("shiroUser", shiroUser);
-        super.getSession().setAttribute("username", shiroUser.getAccount());
+        User user = userService.getByAccount(username);
+        if (user != null && !passwordService.isModern(user.getPassword())) {
+            user.setPassword(passwordService.encode(password));
+            user.setSalt("");
+            userService.updateById(user);
+        }
+        Session authenticatedSession = currentUser.getSession(true);
+        authenticatedSession.setAttribute("shiroUser", shiroUser);
+        authenticatedSession.setAttribute("username", shiroUser.getAccount());
 
         LogManager.me().executeLog(LogTaskFactory.loginLog(shiroUser.getId(), getIp()));
 
-        ShiroKit.getSession().setAttribute("sessionFlag", true);
+        authenticatedSession.setAttribute("sessionFlag", true);
 
         return REDIRECT + "/admin";
     }

--- a/src/main/java/com/jsnjfz/manage/modular/system/controller/NoticeController.java
+++ b/src/main/java/com/jsnjfz/manage/modular/system/controller/NoticeController.java
@@ -24,12 +24,14 @@ import com.jsnjfz.manage.core.common.constant.factory.ConstantFactory;
 import com.jsnjfz.manage.core.common.exception.BizExceptionEnum;
 import com.jsnjfz.manage.core.log.LogObjectHolder;
 import com.jsnjfz.manage.core.shiro.ShiroKit;
+import com.jsnjfz.manage.core.security.RichTextSanitizer;
 import com.jsnjfz.manage.modular.system.model.Notice;
 import com.jsnjfz.manage.modular.system.service.INoticeService;
 import com.jsnjfz.manage.modular.system.warpper.NoticeWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.owasp.encoder.Encode;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -54,6 +56,9 @@ public class NoticeController extends BaseController {
     @Autowired
     private INoticeService noticeService;
 
+    @Autowired
+    private RichTextSanitizer richTextSanitizer;
+
     /**
      * 跳转到通知列表首页
      */
@@ -77,6 +82,9 @@ public class NoticeController extends BaseController {
     public String noticeUpdate(@PathVariable Integer noticeId, Model model) {
         Notice notice = this.noticeService.selectById(noticeId);
         model.addAttribute("notice", notice);
+        model.addAttribute("noticeTitle", Encode.forHtmlAttribute(notice.getTitle()));
+        model.addAttribute("noticeContent",
+                Encode.forHtmlContent(richTextSanitizer.sanitize(notice.getContent())));
         LogObjectHolder.me().set(notice);
         return PREFIX + "notice_edit.html";
     }
@@ -87,6 +95,10 @@ public class NoticeController extends BaseController {
     @RequestMapping("/hello")
     public String hello() {
         List<Map<String, Object>> notices = noticeService.list(null);
+        for (Map<String, Object> notice : notices) {
+            Object content = notice.get("content");
+            notice.put("content", richTextSanitizer.sanitize(content == null ? "" : content.toString()));
+        }
         super.setAttr("noticeList", notices);
         return "/blackboard.html";
     }
@@ -113,6 +125,7 @@ public class NoticeController extends BaseController {
         }
         notice.setCreater(ShiroKit.getUser().getId());
         notice.setCreatetime(new Date());
+        notice.setContent(richTextSanitizer.sanitize(notice.getContent()));
         notice.insert();
         return SUCCESS_TIP;
     }
@@ -145,7 +158,7 @@ public class NoticeController extends BaseController {
         }
         Notice old = this.noticeService.selectById(notice.getId());
         old.setTitle(notice.getTitle());
-        old.setContent(notice.getContent());
+        old.setContent(richTextSanitizer.sanitize(notice.getContent()));
         old.updateById();
         return SUCCESS_TIP;
     }

--- a/src/main/java/com/jsnjfz/manage/modular/system/controller/UserMgrController.java
+++ b/src/main/java/com/jsnjfz/manage/modular/system/controller/UserMgrController.java
@@ -15,10 +15,6 @@
  */
 package com.jsnjfz.manage.modular.system.controller;
 
-import com.jsnjfz.manage.modular.system.factory.UserFactory;
-import com.jsnjfz.manage.modular.system.model.User;
-import com.jsnjfz.manage.modular.system.service.IUserService;
-import com.jsnjfz.manage.modular.system.warpper.UserWarpper;
 import com.jsnjfz.manage.config.properties.GunsProperties;
 import com.jsnjfz.manage.core.common.annotion.BussinessLog;
 import com.jsnjfz.manage.core.common.annotion.Permission;
@@ -27,9 +23,11 @@ import com.jsnjfz.manage.core.common.constant.dictmap.UserDict;
 import com.jsnjfz.manage.core.common.constant.factory.ConstantFactory;
 import com.jsnjfz.manage.core.common.constant.state.ManagerStatus;
 import com.jsnjfz.manage.core.common.exception.BizExceptionEnum;
+import com.jsnjfz.manage.core.common.exception.InvalidUploadException;
 import com.jsnjfz.manage.core.log.LogObjectHolder;
 import com.jsnjfz.manage.core.shiro.ShiroKit;
 import com.jsnjfz.manage.core.shiro.ShiroUser;
+import com.jsnjfz.manage.core.security.PasswordService;
 import com.jsnjfz.manage.modular.system.factory.UserFactory;
 import com.jsnjfz.manage.modular.system.model.User;
 import com.jsnjfz.manage.modular.system.service.IUserService;
@@ -50,10 +48,18 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.naming.NoPermissionException;
 import javax.validation.Valid;
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.UUID;
 
 /**
@@ -65,6 +71,14 @@ import java.util.UUID;
 @Controller
 @RequestMapping("/mgr")
 public class UserMgrController extends BaseController {
+
+    private static final long MAX_IMAGE_BYTES = 5L * 1024 * 1024;
+    private static final long MAX_IMAGE_PIXELS = 16L * 1024 * 1024;
+    private static final Set<String> IMAGE_EXTENSIONS =
+            new HashSet<>(java.util.Arrays.asList("jpg", "jpeg", "png", "gif"));
+
+    @Autowired
+    private PasswordService passwordService;
 
     private static String PREFIX = "/system/user/";
 
@@ -160,10 +174,9 @@ public class UserMgrController extends BaseController {
         }
         Integer userId = ShiroKit.getUser().getId();
         User user = userService.selectById(userId);
-        String oldMd5 = ShiroKit.md5(oldPwd, user.getSalt());
-        if (user.getPassword().equals(oldMd5)) {
-            String newMd5 = ShiroKit.md5(newPwd, user.getSalt());
-            user.setPassword(newMd5);
+        if (passwordService.matches(oldPwd, user.getPassword(), user.getSalt())) {
+            user.setPassword(passwordService.encode(newPwd));
+            user.setSalt("");
             user.updateById();
             return SUCCESS_TIP;
         } else {
@@ -207,8 +220,8 @@ public class UserMgrController extends BaseController {
         }
 
         // 完善账号信息
-        user.setSalt(ShiroKit.getRandomSalt(5));
-        user.setPassword(ShiroKit.md5(user.getPassword(), user.getSalt()));
+        user.setSalt("");
+        user.setPassword(passwordService.encode(user.getPassword()));
         user.setStatus(ManagerStatus.OK.getCode());
         user.setCreatetime(new Date());
 
@@ -292,8 +305,8 @@ public class UserMgrController extends BaseController {
         }
         assertAuth(userId);
         User user = this.userService.selectById(userId);
-        user.setSalt(ShiroKit.getRandomSalt(5));
-        user.setPassword(ShiroKit.md5(Const.DEFAULT_PWD, user.getSalt()));
+        user.setSalt("");
+        user.setPassword(passwordService.encode(Const.DEFAULT_PWD));
         this.userService.updateById(user);
         return SUCCESS_TIP;
     }
@@ -360,13 +373,32 @@ public class UserMgrController extends BaseController {
     @RequestMapping(method = RequestMethod.POST, path = "/upload")
     @ResponseBody
     public String upload(@RequestPart("file") MultipartFile picture) {
-
-        String pictureName = UUID.randomUUID().toString() + "." + ToolUtil.getFileSuffix(picture.getOriginalFilename());
+        String originalFilename = picture.getOriginalFilename();
+        String suffix = originalFilename == null
+                ? "" : ToolUtil.getFileSuffix(originalFilename).toLowerCase(Locale.ROOT);
+        if (picture.isEmpty() || picture.getSize() > MAX_IMAGE_BYTES || !IMAGE_EXTENSIONS.contains(suffix)) {
+            throw new InvalidUploadException();
+        }
+        String outputFormat = "jpeg".equals(suffix) ? "jpg" : suffix;
+        String pictureName = UUID.randomUUID().toString() + "." + outputFormat;
         try {
-            String fileSavePath = gunsProperties.getFileUploadPath();
-            picture.transferTo(new File(fileSavePath + pictureName));
-        } catch (Exception e) {
-            throw new ServiceException(BizExceptionEnum.UPLOAD_ERROR);
+            BufferedImage image = ImageIO.read(picture.getInputStream());
+            if (image == null || image.getWidth() <= 0 || image.getHeight() <= 0
+                    || (long) image.getWidth() * image.getHeight() > MAX_IMAGE_PIXELS) {
+                throw new IOException("Invalid image");
+            }
+            Path uploadRoot = new File(gunsProperties.getFileUploadPath()).toPath()
+                    .toAbsolutePath().normalize();
+            Files.createDirectories(uploadRoot);
+            Path target = uploadRoot.resolve(pictureName).normalize();
+            if (!target.startsWith(uploadRoot)) {
+                throw new IOException("Invalid upload path");
+            }
+            if (!ImageIO.write(image, outputFormat, target.toFile())) {
+                throw new IOException("Unsupported image format");
+            }
+        } catch (IOException e) {
+            throw new InvalidUploadException();
         }
         return pictureName;
     }

--- a/src/main/java/com/jsnjfz/manage/modular/system/dao/mapping/CategoryMapper.xml
+++ b/src/main/java/com/jsnjfz/manage/modular/system/dao/mapping/CategoryMapper.xml
@@ -20,10 +20,11 @@
         select
         id,title,sort,icon,create_time createTime,parent_id parentId,levels
         from category
-        where 1=1
-        <if test="title != null and title != ''">
-            and title like CONCAT('%',#{title},'%')
-        </if>
+        <where>
+            <if test="title != null and title != ''">
+                title like CONCAT('%',#{title},'%')
+            </if>
+        </where>
     </select>
 
     <select id="getList" resultType="com.jsnjfz.manage.modular.system.model.Category" parameterType="map">

--- a/src/main/java/com/jsnjfz/manage/modular/system/dao/mapping/LoginLogMapper.xml
+++ b/src/main/java/com/jsnjfz/manage/modular/system/dao/mapping/LoginLogMapper.xml
@@ -3,13 +3,15 @@
 <mapper namespace="com.jsnjfz.manage.modular.system.dao.LoginLogMapper">
 
 	<select id="getLoginLogs" resultType="map" parameterType="com.baomidou.mybatisplus.plugins.Page">
-		select * from sys_login_log where 1 = 1
-		<if test="beginTime != null and beginTime !='' and endTime != null and endTime != ''">
-			and (createTime between CONCAT(#{beginTime},' 00:00:00') and CONCAT(#{endTime},' 23:59:59'))
-		</if>
-		<if test="logName != null and logName !=''">
-			and logname like CONCAT('%',#{logName},'%')
-		</if>
+		select * from sys_login_log
+		<where>
+			<if test="beginTime != null and beginTime !='' and endTime != null and endTime != ''">
+				(createTime between CONCAT(#{beginTime},' 00:00:00') and CONCAT(#{endTime},' 23:59:59'))
+			</if>
+			<if test="logName != null and logName !=''">
+				and logname like CONCAT('%',#{logName},'%')
+			</if>
+		</where>
 		<choose>
 			<when test="orderByField != null and orderByField !=''">
 				<choose>

--- a/src/main/java/com/jsnjfz/manage/modular/system/dao/mapping/OperationLogMapper.xml
+++ b/src/main/java/com/jsnjfz/manage/modular/system/dao/mapping/OperationLogMapper.xml
@@ -3,16 +3,18 @@
 <mapper namespace="com.jsnjfz.manage.modular.system.dao.OperationLogMapper">
 
 	<select id="getOperationLogs" resultType="map">
-		select * from sys_operation_log where 1 = 1
-		<if test="beginTime != null and beginTime !='' and endTime != null and endTime != ''">
-			and (createTime between CONCAT(#{beginTime},' 00:00:00') and CONCAT(#{endTime},' 23:59:59'))
-		</if>
-		<if test="logName != null and logName !=''">
-			and logname like CONCAT('%',#{logName},'%')
-		</if>
-		<if test="logType != null and logType !=''">
-			and logtype like CONCAT('%',#{logType},'%')
-		</if>
+		select * from sys_operation_log
+		<where>
+			<if test="beginTime != null and beginTime !='' and endTime != null and endTime != ''">
+				(createTime between CONCAT(#{beginTime},' 00:00:00') and CONCAT(#{endTime},' 23:59:59'))
+			</if>
+			<if test="logName != null and logName !=''">
+				and logname like CONCAT('%',#{logName},'%')
+			</if>
+			<if test="logType != null and logType !=''">
+				and logtype like CONCAT('%',#{logType},'%')
+			</if>
+		</where>
 		<choose>
 			<when test="orderByField != null and orderByField !=''">
 				<choose>

--- a/src/main/java/com/jsnjfz/manage/modular/system/dao/mapping/SiteMapper.xml
+++ b/src/main/java/com/jsnjfz/manage/modular/system/dao/mapping/SiteMapper.xml
@@ -13,20 +13,22 @@
     <select id="getList" resultType="com.jsnjfz.manage.modular.system.model.Site" parameterType="map">
         select s.*,c.title categoryTitle
         from site s left join category c on s.category_id = c.id
-        where 1=1
-        <if test="title != null and title != ''">
-            and s.title like CONCAT('%',#{title},'%')
-        </if>
+        <where>
+            <if test="title != null and title != ''">
+                s.title like CONCAT('%',#{title},'%')
+            </if>
+        </where>
         <if test="offset != null">LIMIT #{offset},#{size}</if>
     </select>
 
     <select id="getTotalCount" resultType="java.lang.Integer" parameterType="map">
         select count(1)
         from site
-        where 1=1
-        <if test="title != null and title != ''">
-            and title like CONCAT('%',#{title},'%')
-        </if>
+        <where>
+            <if test="title != null and title != ''">
+                title like CONCAT('%',#{title},'%')
+            </if>
+        </where>
     </select>
 
 

--- a/src/main/java/com/jsnjfz/manage/modular/system/model/User.java
+++ b/src/main/java/com/jsnjfz/manage/modular/system/model/User.java
@@ -215,8 +215,6 @@ public class User extends Model<User> {
                 "id=" + id +
                 ", avatar=" + avatar +
                 ", account=" + account +
-                ", password=" + password +
-                ", salt=" + salt +
                 ", name=" + name +
                 ", birthday=" + birthday +
                 ", sex=" + sex +

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,23 @@
 server:
-  port: 8000
+  address: ${SERVER_ADDRESS:127.0.0.1}
+  port: ${SERVER_PORT:8000}
+  servlet:
+    session:
+      persistent: false
+  compression:                    #开启响应压缩：app.css 799KB->78KB，app.js 303KB->95KB
+    enabled: true
+    mime-types: text/html,text/css,text/plain,text/xml,text/javascript,application/javascript,application/json,application/xml,image/svg+xml
+    min-response-size: 1024
 
 guns:
-  swagger-open: true              #是否开启swagger (true/false)
-  kaptcha-open: false             #是否开启登录时验证码 (true/false)
-  file-upload-path: c:/tmp     #文件上传目录(不配置的话为java.io.tmpdir目录)
-  spring-session-open: false      #是否开启spring session,如果是多机环境需要开启(true/false)
+  swagger-open: ${GUNS_SWAGGER_OPEN:false}              #是否开启swagger (true/false)
+  kaptcha-open: ${GUNS_KAPTCHA_OPEN:false}              #是否开启登录时验证码 (true/false)
+  file-upload-path: ${GUNS_FILE_UPLOAD_PATH:}            #文件上传目录(不配置的话为java.io.tmpdir目录)
+  spring-session-open: ${GUNS_SPRING_SESSION_OPEN:false} #是否开启spring session,如果是多机环境需要开启(true/false)
+  secure-cookie: ${GUNS_SECURE_COOKIE:false}             #HTTPS 部署必须设为 true
+  druid-monitor-open: ${GUNS_DRUID_MONITOR_OPEN:false}
+  jwt-secret: ${GUNS_JWT_SECRET:}
+  remember-me-cipher-key: ${GUNS_REMEMBER_ME_CIPHER_KEY:}
   session-invalidate-time: 1800     #session失效时间(只在单机环境下生效，多机环境在SpringSessionConfig类中配置) 单位：秒
   session-validation-interval: 900  #多久检测一次失效的session(只在单机环境下生效) 单位：秒
 
@@ -13,9 +25,13 @@ beetl:
   resource-auto-check: true       #热加载beetl模板，开发时候用
 
 spring:
+  main:
+    allow-circular-references: true
   profiles:
     active: @spring.active@
   mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
     static-path-pattern: /static/**
     view:
       prefix: /WEB-INF/view
@@ -26,8 +42,13 @@ spring:
       exclude: static/**,WEB-INF/view/**
   servlet:
     multipart:
-      max-request-size: 100MB
-      max-file-size: 100MB
+      max-request-size: 5MB
+      max-file-size: 5MB
+  web:
+    resources:
+      cache:
+        cachecontrol:
+          max-age: 1d           #静态资源浏览器缓存；资源名无内容哈希，故不宜设置过长
 
 mybatis-plus:
   typeAliasesPackage: com.jsnjfz.manage.modular.system.model
@@ -38,12 +59,12 @@ log:
 ---
 
 spring:
-  profiles: local
+  config:
+    activate:
+      on-profile: local
   datasource:
-    url: jdbc:mysql://localhost/guns?autoReconnect=true&useUnicode=true&characterEncoding=utf8&zeroDateTimeBehavior=CONVERT_TO_NULL&useSSL=false&serverTimezone=Asia/Shanghai
-    username: root
-    password: root
+    url: ${DB_URL:jdbc:mysql://127.0.0.1:3306/guns?autoReconnect=true&useUnicode=true&characterEncoding=utf8&zeroDateTimeBehavior=CONVERT_TO_NULL&useSSL=false&serverTimezone=Asia/Shanghai}
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:}
     filters: wall,mergeStat
-
-
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,8 @@ spring:
 
 mybatis-plus:
   typeAliasesPackage: com.jsnjfz.manage.modular.system.model
+  configuration:
+    log-impl: org.apache.ibatis.logging.slf4j.Slf4jImpl
 
 log:
   path: manage-logs
@@ -67,4 +69,3 @@ spring:
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:}
     filters: wall,mergeStat
-

--- a/src/main/webapp/WEB-INF/view/about.html
+++ b/src/main/webapp/WEB-INF/view/about.html
@@ -8,63 +8,66 @@
     <div class="navbar-inner">
         <div class="navbar-brand">
             <a href="/" class="logo">
-                <img src="/static/img/logo_dark\@2x.png" width="100%" alt="" class="hidden-xs">
-                <img src="/static/img/logo2x.png" width="100%" alt="" class="visible-xs">
+                <img src="/static/img/logo_dark\@2x.png" width="100%" alt="返回首页" class="hidden-xs">
+                <img src="/static/img/logo2x.png" width="100%" alt="返回首页" class="visible-xs">
             </a>
         </div>
         <div class="navbar-mobile-clear"></div>
-        <a href="https://github.com/jsnjfz/WebStack-Guns" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
+        <div class="nav-toolbar">
+            <button id="nav-theme-toggle" class="nav-theme-toggle" type="button"
+                    aria-label="切换深色模式">
+                <i class="fa fa-moon-o" aria-hidden="true"></i>
+            </button>
+            <a class="nav-github-link" href="https://github.com/jsnjfz/WebStack-Guns"
+               target="_blank" rel="noopener noreferrer" aria-label="在 GitHub 上查看本项目">
+                <img src="/static/img/github.png" width="22" height="22" alt="" aria-hidden="true">
+            </a>
+        </div>
     </div>
 </nav>
 <div class="page-container">
-    <!-- add class "sidebar-collapsed" to close sidebar by default, "chat-visible" to make chat appear always -->
     <div class="main-content" style="">
         <div class="row">
             <div class="col-md-12">
                 <div class="panel panel-default">
                     <!-- 关于项目 -->
-                    <h4 class="text-gray">关于项目</h4>
+                    <h1 class="nav-section-title">关于项目</h1>
                     <div class="panel-body">
                         <div class="row">
                             <div class="col-sm-12">
                                 <blockquote>
                                     <p>这是一个开源的网址导航网站项目，您可以拿来制作自己的网址导航，也可以做与导航无关的网站。</p>
-                                    </br>
-                                    <p>网站前台静态页面采用 <a href="http://viggoz.com/" target="_blank">viggoz</a> 的 <a href="https://github.com/WebStackPage/WebStackPage.github.io">WebStack</a> 项目源码。</p>
+                                    <p>网站前台静态页面采用 <a href="http://viggoz.com/" target="_blank" rel="noopener noreferrer">viggoz</a> 的 <a href="https://github.com/WebStackPage/WebStackPage.github.io" target="_blank" rel="noopener noreferrer">WebStack</a> 项目源码。</p>
                                     <p>如果对本项目有任何建议都可以发起 issue。</p>
                                 </blockquote>
                             </div>
                         </div>
                         <!-- 关于作者 -->
-                        <h4 class="text-gray">关于作者</h4>
+                        <h2 class="nav-section-title">关于作者</h2>
                         <div class="row">
-                            <div class="col-sm-4">
-                                <div class="xe-widget xe-conversations box2 label-info" onclick="window.open('http://www.viggoz.com/', '_blank')" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="http://www.viggoz.com/">
+                            <div class="col-xs-12 col-sm-6 col-md-4 nav-col">
+                                <a class="xe-widget xe-conversations box2 label-info nav-card"
+                                   href="http://www.viggoz.com/" target="_blank" rel="noopener noreferrer">
                                     <div class="xe-comment-entry">
-                                        <a class="xe-user-img">
-                                            <img src="https://secure.gravatar.com/avatar/41100536f1c27b5282100eb0c41aa90d" class="img-circle" width="40">
-                                        </a>
+                                        <span class="xe-user-img">
+                                            <img src="https://secure.gravatar.com/avatar/41100536f1c27b5282100eb0c41aa90d"
+                                                 onerror="this.onerror=null;this.src='/static/img/github.png';"
+                                                 class="img-circle nav-card-icon"
+                                                 width="40" height="40" loading="lazy" decoding="async" alt="">
+                                        </span>
                                         <div class="xe-comment">
-                                            <a href="#" class="xe-user-name overflowClip_1">
-                                                <strong>Designer. jsnjfz</strong>
-                                            </a>
-                                            <p class="overflowClip_2"> 250809345\@qq.com</p>
+                                            <span class="xe-user-name overflowClip_1"><strong>Designer. jsnjfz</strong></span>
+                                            <p class="overflowClip_2">250809345\@qq.com</p>
                                         </div>
                                     </div>
-                                </div>
+                                </a>
                             </div>
-                            <div class="col-md-8">
-                                <div class="row">
-                                    <div class="col-sm-12">
-                                        <br />
-                                        <blockquote>
-                                            <p>
-                                                这是一个<a href="https://github.com/jsnjfz/WebStack-Guns"> 开源项目 </a>。你可以拿来制作自己的网址导航。如果你有更好的想法，可以通过邮件与我联系，或者在github上提issue，欢迎与我交流分享。
-                                            </p>
-                                        </blockquote>
-                                    </div>
-                                </div>
-                                <br>
+                            <div class="col-xs-12 col-sm-6 col-md-8">
+                                <blockquote>
+                                    <p>
+                                        这是一个<a href="https://github.com/jsnjfz/WebStack-Guns" target="_blank" rel="noopener noreferrer"> 开源项目 </a>。你可以拿来制作自己的网址导航。如果你有更好的想法，可以通过邮件与我联系，或者在 github 上提 issue，欢迎与我交流分享。
+                                    </p>
+                                </blockquote>
                             </div>
                         </div>
                     </div>
@@ -75,17 +78,19 @@
         <footer class="main-footer sticky footer-type-1 fixed">
             <div class="footer-inner">
                 <div class="footer-text">
-                    &copy; 2019
-                    <a href="/"><strong>WebStack</strong></a> design by <a href="https://github.com/jsnjfz" target="_blank"><strong>jsnjfz</strong></a>
+                    &copy; <span id="nav-year">2019</span>
+                    <a href="/"><strong>WebStack</strong></a> design by <a href="https://github.com/jsnjfz" target="_blank" rel="noopener noreferrer"><strong>jsnjfz</strong></a>
                 </div>
                 <div class="go-up">
-                    <a href="#" rel="go-top">
-                        <i class="fa-angle-up"></i>
+                    <a href="#" rel="go-top" aria-label="回到顶部">
+                        <i class="fa-angle-up" aria-hidden="true"></i>
                     </a>
                 </div>
             </div>
         </footer>
     </div>
 </div>
+
+<script src="/static/js/app.js"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/view/common/_content.html
+++ b/src/main/webapp/WEB-INF/view/common/_content.html
@@ -1,25 +1,31 @@
 @for(categorySite in categorySiteList){
     @if(isNotEmpty(categorySite.sites)){
-    <h4 class="text-gray"><i class="linecons-tag" style="margin-right: 7px;" id="${categorySite.title}"></i>${categorySite.title}</h4>
-        <div class="row">
+    <section class="nav-section" data-section="${categorySite.title}">
+        <h2 class="nav-section-title" id="${categorySite.title}">
+            <i class="linecons-tag" aria-hidden="true"></i>${categorySite.title}
+        </h2>
+        <div class="row nav-grid">
             @for(site in categorySite.sites){
-            <div class="col-sm-3">
-                <div class="xe-widget xe-conversations box2 label-info" onclick="window.open('${site.url}', '_blank')" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="${site.url}">
+            <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 nav-col">
+                <a class="xe-widget xe-conversations box2 label-info nav-card"
+                   href="${site.url}" target="_blank" rel="noopener noreferrer">
                     <div class="xe-comment-entry">
-                        <a class="xe-user-img">
-                            <img src="/kaptcha/${site.thumb}" class="img-circle" width="40">
-                        </a>
+                        <span class="xe-user-img">
+                            <img src="/static/tmp/${site.thumb}"
+                                 class="img-circle nav-card-icon"
+                                 width="40" height="40" loading="lazy" decoding="async" alt="">
+                        </span>
                         <div class="xe-comment">
-                            <a href="#" class="xe-user-name overflowClip_1">
-                                <strong>${site.title}</strong>
-                            </a>
+                            <span class="xe-user-name overflowClip_1"><strong>${site.title}</strong></span>
                             <p class="overflowClip_2">${site.description}</p>
                         </div>
                     </div>
-                </div>
+                </a>
             </div>
             @}
         </div>
-    <br>
+    </section>
     @}
 @}
+
+<p id="nav-no-result" class="nav-no-result" hidden>没有找到匹配的站点，换个关键词试试</p>

--- a/src/main/webapp/WEB-INF/view/common/_header.html
+++ b/src/main/webapp/WEB-INF/view/common/_header.html
@@ -2,19 +2,33 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta name="author" content="viggo">
-    <title>webstack导航</title>
-    <meta name="keywords" content="新媒体，新媒体运营,新媒体工具,新媒体营销,新媒体智库">
-    <meta name="description" content="新媒体百宝箱-新媒体工作者快捷工具导航">
-    <link rel="shortcut icon" href="https://www.xmtbbx.com/img/favicon.png">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Arimo:400,700,400italic">
-    <link rel="stylesheet" href="/static/css/app.css">
-    <link rel="stylesheet" href="/static/css/login.css">
-    <script src="/static/js/app.js"></script>
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-        <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-        <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
 
+    <title>设计导航 - 设计资源与在线工具集合</title>
+    <meta name="author" content="jsnjfz">
+    <meta name="keywords" content="设计导航,设计资源,UI资源,图标素材,LOGO设计,配色工具,字体资源,摄影图库,Mockup,Sketch资源,在线工具,Chrome插件">
+    <meta name="description" content="面向设计师的网址导航：汇总 UI 资源、图标素材、LOGO 设计、配色工具、字体、摄影图库、Mockup、交互动效与在线工具等常用站点。">
+
+    <link rel="shortcut icon" href="/static/favicon.ico">
+
+    <!-- 防止深色模式首屏闪白：必须内联且早于样式表生效，逻辑与 nav.js 保持一致 -->
+    <script>
+        (function () {
+            try {
+                var t = localStorage.getItem('nav-theme');
+                if (t !== 'dark' && t !== 'light') {
+                    t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+                }
+                document.documentElement.setAttribute('data-theme', t);
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+
+    <link rel="stylesheet" href="/static/css/app.css">
+    <!-- 前台导航页样式覆盖层，必须排在 app.css 之后 -->
+    <link rel="stylesheet" href="/static/css/nav.css">
+
+    <!-- 搜索/主题/平滑滚动，纯原生 JS，defer 不阻塞渲染 -->
+    <script src="/static/js/nav.js" defer></script>
 </head>

--- a/src/main/webapp/WEB-INF/view/common/_sidebar.html
+++ b/src/main/webapp/WEB-INF/view/common/_sidebar.html
@@ -4,34 +4,34 @@
             <!-- logo -->
             <div class="logo">
                 <a href="/" class="logo-expanded">
-                    <img src="/static/img/logo2x.png" width="100%" alt="" />
+                    <img src="/static/img/logo2x.png" width="100%" alt="设计导航首页" />
                 </a>
                 <a href="/" class="logo-collapsed">
-                    <img src="/static/img/logo-collapsed2x.png" width="40" alt="" />
+                    <img src="/static/img/logo-collapsed2x.png" width="40" alt="设计导航首页" />
                 </a>
             </div>
             <div class="mobile-menu-toggle visible-xs">
-                <a href="#" data-toggle="user-info-menu">
-                    <i class="linecons-cog"></i>
+                <a href="#" data-toggle="user-info-menu" aria-label="更多操作">
+                    <i class="linecons-cog" aria-hidden="true"></i>
                 </a>
-                <a href="#" data-toggle="mobile-menu">
-                    <i class="fa-bars"></i>
+                <a href="#" data-toggle="mobile-menu" aria-label="展开分类菜单">
+                    <i class="fa-bars" aria-hidden="true"></i>
                 </a>
             </div>
         </header>
-        <ul id="main-menu" class="main-menu">
+        <ul id="main-menu" class="main-menu" role="navigation" aria-label="站点分类">
             @for(title in titles){
                 @if(tool.isEmpty(title.children)){
                 <li>
                     <a href="#${title.name}" class="smooth">
-                        <i class="fa fa-fw ${title.icon}"></i>
+                        <i class="fa fa-fw ${title.icon}" aria-hidden="true"></i>
                         <span class="title">${title.name}</span>
                     </a>
                 </li>
                 @}else{
                 <li>
                     <a>
-                        <i class="fa fa-fw ${title.icon}"></i>
+                        <i class="fa fa-fw ${title.icon}" aria-hidden="true"></i>
                         <span class="title">${title.name}</span>
                     </a>
                     <ul>
@@ -47,13 +47,13 @@
                 @}
             @}
 
-            <div class="submit-tag">
+            <li class="submit-tag">
                 <a href="/about">
-                    <i class="linecons-heart"></i>
+                    <i class="linecons-heart" aria-hidden="true"></i>
                     <span class="tooltip-blue">关于本站</span>
-                    <span class="label label-Primary pull-right hidden-collapsed">♥︎</span>
+                    <span class="label label-Primary pull-right hidden-collapsed">&hearts;</span>
                 </a>
-            </div>
+            </li>
         </ul>
     </div>
 </div>

--- a/src/main/webapp/WEB-INF/view/index.html
+++ b/src/main/webapp/WEB-INF/view/index.html
@@ -6,43 +6,58 @@
 
 
 <body class="page-body">
-    <!-- skin-white -->
+    <a class="nav-skip-link" href="#nav-main">跳到主内容</a>
+
     <div class="page-container">
 
         @include("/common/_sidebar.html"){}
 
         <div class="main-content">
             <nav class="navbar user-info-navbar" role="navigation">
-                <!-- User Info, Notifications and Menu Bar -->
-                <!-- Left links for user info navbar -->
                 <ul class="user-info-menu left-links list-inline list-unstyled">
                     <li class="hidden-sm hidden-xs">
-                        <a href="#" data-toggle="sidebar">
-                            <i class="fa-bars"></i>
+                        <a href="#" data-toggle="sidebar" aria-label="收起或展开侧边栏">
+                            <i class="fa-bars" aria-hidden="true"></i>
                         </a>
                     </li>
                 </ul>
 
-            <a href="https://github.com/jsnjfz/WebStack-Guns" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
+                <div class="nav-toolbar">
+                    <div class="nav-search-wrap">
+                        <i class="fa fa-search nav-search-icon" aria-hidden="true"></i>
+                        <label class="sr-only" for="nav-search">搜索站点</label>
+                        <input id="nav-search" class="nav-search" type="search"
+                               placeholder="搜索站点，按 / 快速聚焦" autocomplete="off">
+                        <button id="nav-search-clear" class="nav-search-clear" type="button"
+                                aria-label="清空搜索" hidden>&times;</button>
+                    </div>
+                    <button id="nav-theme-toggle" class="nav-theme-toggle" type="button"
+                            aria-label="切换深色模式">
+                        <i class="fa fa-moon-o" aria-hidden="true"></i>
+                    </button>
+                    <a class="nav-github-link" href="https://github.com/jsnjfz/WebStack-Guns"
+                       target="_blank" rel="noopener noreferrer" aria-label="在 GitHub 上查看本项目">
+                        <img src="/static/img/github.png" width="22" height="22" alt="" aria-hidden="true">
+                    </a>
+                </div>
             </nav>
 
-            @include("/common/_content.html"){}
+            <div id="nav-main">
+                <h1 class="nav-page-title">设计导航 · 精选设计资源与在线工具</h1>
+
+                @include("/common/_content.html"){}
+            </div>
 
             <!-- Main Footer -->
-            <!-- Choose between footer styles: "footer-type-1" or "footer-type-2" -->
-            <!-- Add class "sticky" to  always stick the footer to the end of page (if page contents is small) -->
-            <!-- Or class "fixed" to  always fix the footer to the end of page -->
             <footer class="main-footer sticky footer-type-1">
                 <div class="footer-inner">
-                    <!-- Add your copyright text here -->
                     <div class="footer-text">
-                        &copy; 2019
-                        <a href="/"><strong>WebStack</strong></a> design by <a href="https://github.com/jsnjfz" target="_blank"><strong>jsnjfz</strong></a>
+                        &copy; <span id="nav-year">2019</span>
+                        <a href="/"><strong>WebStack</strong></a> design by <a href="https://github.com/jsnjfz" target="_blank" rel="noopener noreferrer"><strong>jsnjfz</strong></a>
                     </div>
-                    <!-- Go to Top Link, just add rel="go-top" to any link to add this functionality -->
                     <div class="go-up">
-                        <a href="#" rel="go-top">
-                            <i class="fa-angle-up"></i>
+                        <a href="#" rel="go-top" aria-label="回到顶部">
+                            <i class="fa-angle-up" aria-hidden="true"></i>
                         </a>
                     </div>
                 </div>
@@ -50,8 +65,11 @@
         </div>
     </div>
 
-
+    <!-- 主题脚本（含 jQuery）放在底部，避免阻塞首屏渲染 -->
+    <script src="/static/js/app.js"></script>
     <script type="text/javascript">
+    // 侧边栏子菜单展开/收起的主题兼容处理。
+    // 平滑滚动、滚动高亮、死锚点清理已统一由 /static/js/nav.js 接管。
     $(document).ready(function() {
         $(document).on('click', '.has-sub', function(){
             var _this = $(this)
@@ -78,35 +96,6 @@
                 $('.has-sub.expanded > ul').show()
             }
         })
-        $("#main-menu li ul li").click(function() {
-            $(this).siblings('li').removeClass('active'); // 删除其他兄弟元素的样式
-            $(this).addClass('active'); // 添加当前元素的样式
-        });
-        $("a.smooth").click(function(ev) {
-            ev.preventDefault();
-
-            public_vars.$mainMenu.add(public_vars.$sidebarProfile).toggleClass('mobile-is-visible');
-            ps_destroy();
-            $("html, body").animate({
-                scrollTop: $($(this).attr("href")).offset().top - 30
-            }, {
-                duration: 500,
-                easing: "swing"
-            });
-        });
-        return false;
-    });
-
-    var href = "";
-    var pos = 0;
-    $("a.smooth").click(function(e) {
-        $("#main-menu li").each(function() {
-            $(this).removeClass("active");
-        });
-        $(this).parent("li").addClass("active");
-        e.preventDefault();
-        href = $(this).attr("href");
-        pos = $(href).position().top - 30;
     });
     </script>
 

--- a/src/main/webapp/WEB-INF/view/login.html
+++ b/src/main/webapp/WEB-INF/view/login.html
@@ -30,6 +30,7 @@
 
         <div class="middle-box">
             <form class="m-t" role="form" action="${ctxPath}/login" method="post">
+                <input type="hidden" name="_csrf" value="${csrfToken!}">
                 <div class="form-group">
                     <input type="text" name="username" class="form-control" placeholder="用户名" required="">
                 </div>

--- a/src/main/webapp/WEB-INF/view/system/notice/notice_add.html
+++ b/src/main/webapp/WEB-INF/view/system/notice/notice_add.html
@@ -34,6 +34,6 @@
 
     </div>
 </div>
-<script type="text/javascript" src="//unpkg.com/wangeditor/release/wangEditor.min.js"></script>
+<script type="text/javascript" src="${ctxPath}/static/js/plugins/wangEditor/wangEditor.js"></script>
 <script src="${ctxPath}/static/modular/system/notice/notice_info.js"></script>
 @}

--- a/src/main/webapp/WEB-INF/view/system/notice/notice_edit.html
+++ b/src/main/webapp/WEB-INF/view/system/notice/notice_edit.html
@@ -4,14 +4,14 @@
         <div class="form-horizontal" id="noticeInfoForm">
 
             <input type="hidden" id="id" value="${notice.id}">
-            <input type="hidden" id="contentVal" value='${notice.content}'>
+            <textarea id="contentVal" style="display:none">${noticeContent}</textarea>
 
             <div class="row">
                 <div class="col-sm-12">
                     <div class="form-group">
                         <label class="col-sm-1 control-label">标题</label>
                         <div class="col-sm-11">
-                            <input class="form-control" id="title" name="title" type="text" value="${notice.title}">
+                            <input class="form-control" id="title" name="title" type="text" value="${noticeTitle}">
 
                         </div>
                     </div>

--- a/src/main/webapp/static/css/nav.css
+++ b/src/main/webapp/static/css/nav.css
@@ -1,0 +1,408 @@
+/*!
+ * nav.css - 前台导航首页样式覆盖层
+ * ------------------------------------------------------------
+ * 本文件在 app.css（Bootstrap 3 + 主题，799KB）之后加载，
+ * 利用“同特异性、后加载者胜出”的层叠规则覆盖 app.css 中的
+ * 既有选择器，不修改 app.css 本身，避免影响后台等其他页面。
+ *
+ * 顶部定义一套语义化 CSS 变量（亮色值对齐 app.css 现有取值），
+ * 并通过 [data-theme="dark"] 提供暗色取值；下方各选择器统一
+ * 读取变量，从而同时驱动亮/暗两套外观。
+ *
+ * 依赖契约：Bootstrap 3 栅格 (xs<768 / sm>=768 / md>=992 / lg>=1200)、
+ * Font Awesome 4、无构建步骤的纯 CSS。
+ * ------------------------------------------------------------ */
+
+/* ========== 1. 主题变量：亮色（默认） ========== */
+:root {
+  /* 页面与容器底色 */
+  --nav-bg: #f9f9f9;              /* 对齐 app.css body 背景 */
+  --nav-card-bg: #ffffff;         /* 对齐 .box2 背景 */
+  --nav-card-border: #e4ecf3;     /* 对齐 .box2 边框 */
+  --nav-toolbar-bg: #ffffff;      /* 对齐 .user-info-navbar 背景 */
+  --nav-footer-bg: #ffffff;       /* 页脚底色 */
+  --nav-sidebar-bg: #2c2e2f;      /* 对齐 .sidebar-menu 背景 */
+  --nav-sidebar-link: #979898;    /* 对齐侧边栏链接色 */
+  --nav-sidebar-border: #313437;  /* 对齐侧边栏分隔线 */
+  --nav-input-bg: #f5f6f8;        /* 搜索框底色 */
+  --nav-icon-bg: #ffffff;         /* 站点图标圆形底，防止透明 PNG 糊掉 */
+
+  /* 文字色阶 */
+  --nav-text-primary: #333333;    /* 正文/卡片标题 */
+  /* 原主题此处为 #999，在白底卡片上仅 2.85:1，低于 WCAG AA 的 4.5:1；
+     卡片描述是首页主要正文，故下调明度至 4.6:1，观感仍保持次要文字的克制 */
+  /* 取值需同时满足白色卡片(#fff)和页面底色(#f9f9f9)两种背景：4.93:1 / 4.68:1 */
+  --nav-text-secondary: #6b7178;  /* 描述/次要文字/占位符 */
+  --nav-heading: #222222;         /* 分区标题 */
+
+  /* 强调色与阴影 */
+  --nav-accent: #2f96e0;
+  --nav-accent-rgb: 47, 150, 224;
+  --nav-shadow-hover: rgba(0, 36, 100, 0.3); /* 对齐 .box2:hover 阴影 */
+
+  /* 通用尺寸 */
+  --nav-radius: 4px;
+  --nav-transition: all 0.3s ease;
+}
+
+/* ========== 2. 主题变量：暗色 ========== */
+[data-theme="dark"] {
+  --nav-bg: #16181d;
+  --nav-card-bg: #1e2128;
+  --nav-card-border: rgba(255, 255, 255, 0.08);
+  --nav-toolbar-bg: #1b1d23;
+  --nav-footer-bg: #1b1d23;
+  --nav-sidebar-bg: #202226;
+  --nav-sidebar-link: #9aa0aa;
+  --nav-sidebar-border: #2a2d33;
+  --nav-input-bg: #24272e;
+  --nav-icon-bg: #ffffff;
+
+  /* 以下文字色相对各自背景对比度均 >= 4.5:1（WCAG AA） */
+  --nav-text-primary: #e8e9ec;
+  --nav-text-secondary: #a8adb7;
+  --nav-heading: #f5f6f8;
+
+  --nav-accent: #4dabf5;
+  --nav-accent-rgb: 77, 171, 245;
+  --nav-shadow-hover: rgba(0, 0, 0, 0.55); /* 暗色下阴影改为纯黑而非偏蓝 */
+}
+
+/* ========== 3. 变量落地：覆盖 app.css 既有选择器 ========== */
+body {
+  background-color: var(--nav-bg);
+}
+.page-container .main-content {
+  background-color: var(--nav-bg);
+}
+/* app.css 里 .xe-widget.xe-conversations 以 (0,2,0) 设了 background:#fff，
+   单靠 .box2 (0,1,0) 覆盖不掉，这里必须用同等及以上特异性 */
+.nav-card.box2,
+.xe-widget.xe-conversations.box2 {
+  background-color: var(--nav-card-bg);
+  border-color: var(--nav-card-border);
+}
+.nav-card.box2:hover,
+.xe-widget.xe-conversations.box2:hover {
+  box-shadow: 0 26px 40px -24px var(--nav-shadow-hover);
+}
+.user-info-navbar {
+  background-color: var(--nav-toolbar-bg);
+  border-bottom-color: var(--nav-card-border);
+}
+/* app.css 给顶栏按钮写死了 border-bottom:1px solid #fff，暗色下会显成一道亮边 */
+.user-info-navbar .user-info-menu > li > a {
+  border-bottom-color: transparent;
+  color: var(--nav-text-secondary);
+}
+footer.main-footer {
+  background-color: var(--nav-footer-bg);
+  color: var(--nav-text-secondary);
+}
+.sidebar-menu {
+  background: var(--nav-sidebar-bg);
+}
+.sidebar-menu .main-menu a {
+  color: var(--nav-sidebar-link);
+  border-bottom-color: var(--nav-sidebar-border);
+}
+.xe-comment p {
+  color: var(--nav-text-secondary);
+}
+.xe-user-name strong {
+  color: var(--nav-heading);
+}
+h1,
+h2 {
+  color: var(--nav-heading);
+}
+.text-gray {
+  color: var(--nav-text-secondary);
+}
+::selection {
+  background: var(--nav-accent);
+  color: #fff;
+}
+
+/* ========== 4. 响应式网格：超宽屏补充列数 ========== */
+/* 模板已提供 col-xs-12/col-sm-6/col-md-4/col-lg-3（1/2/3/4 列），
+   这里针对大屏追加 5 列、6 列，避免 1920px+ 下右侧大片留白 */
+
+/* Bootstrap 3 的 .col-* 是 float 布局，卡片高度不一致时后面的卡片会被
+   前一张"卡住"，出现每行 5,5,1,1 这种错位。改用 flex 换行彻底规避，
+   顺带让同一行的卡片等高。.nav-col 仍保留 Bootstrap 的百分比宽度和 padding。 */
+.nav-grid {
+  display: flex;
+  flex-wrap: wrap;
+}
+.nav-col {
+  float: none;
+  display: flex;
+}
+.nav-col > .nav-card {
+  width: 100%;
+}
+
+@media (min-width: 1600px) {
+  .nav-col {
+    width: 20%;
+  }
+}
+@media (min-width: 2100px) {
+  .nav-col {
+    width: 16.6666667%;
+  }
+}
+
+/* ========== 5. 卡片：布局修复与截断降级 ========== */
+.nav-card,
+.nav-card:hover,
+.nav-card:focus,
+.nav-card:active,
+.nav-card:visited {
+  color: inherit;
+  text-decoration: none;
+}
+.nav-card {
+  display: flex;
+  align-items: center;
+  height: auto;
+  min-height: 86px; /* 由固定 height 改为最小高度，允许内容撑开 */
+}
+.nav-card .xe-comment-entry {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+.nav-card .xe-user-img {
+  flex: 0 0 40px;
+}
+.nav-card-icon {
+  display: block;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
+  float: none;
+  object-fit: contain;
+  background: var(--nav-icon-bg);
+  padding: 4px;
+  box-sizing: border-box;
+}
+.nav-card .xe-comment {
+  flex: 1 1 auto;
+  min-width: 0; /* flex 子项收缩前提，配合省略号截断 */
+}
+.nav-card .xe-user-name {
+  display: block;
+}
+/* -webkit-line-clamp 在少数非 WebKit 内核下不生效时的降级兜底，
+   避免长文本撑破卡片高度 */
+.overflowClip_1,
+.overflowClip_2 {
+  overflow: hidden;
+}
+.overflowClip_1 {
+  max-height: 1.6em;
+}
+.overflowClip_2 {
+  max-height: 3.2em;
+}
+
+@media (max-width: 767px) {
+  .box2 {
+    padding: 0 16px;
+  }
+}
+
+/* ========== 6. 工具条：搜索框 / 主题切换 ========== */
+.nav-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
+  height: 100%;
+  padding: 0 20px;
+}
+.nav-search-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+.nav-search-icon {
+  position: absolute;
+  left: 12px;
+  color: var(--nav-text-secondary);
+  font-size: 13px;
+  pointer-events: none;
+}
+.nav-search {
+  width: 220px;
+  max-width: 50vw;
+  padding: 6px 30px;
+  border: 1px solid var(--nav-card-border);
+  border-radius: 20px;
+  background: var(--nav-input-bg);
+  color: var(--nav-text-primary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.nav-search::placeholder {
+  color: var(--nav-text-secondary);
+}
+.nav-search:focus {
+  outline: none;
+  border-color: var(--nav-accent);
+  box-shadow: 0 0 0 3px rgba(var(--nav-accent-rgb), 0.25);
+}
+.nav-search-clear {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: transparent;
+  color: var(--nav-text-secondary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 6px;
+}
+.nav-search-clear:hover {
+  color: var(--nav-text-primary);
+}
+.nav-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--nav-card-border);
+  border-radius: 50%;
+  background: var(--nav-card-bg);
+  color: var(--nav-text-secondary);
+  cursor: pointer;
+  transition: var(--nav-transition);
+}
+.nav-theme-toggle:hover {
+  color: var(--nav-accent);
+  border-color: var(--nav-accent);
+}
+@media (max-width: 767px) {
+  .nav-toolbar {
+    justify-content: flex-end;
+    padding: 0 10px;
+    gap: 8px;
+  }
+  .nav-search {
+    width: 130px;
+    max-width: 45vw;
+  }
+}
+
+/* ========== 7. 分区间距与标题 ========== */
+.nav-page-title {
+  /* 父级 .main-content 已有 30px padding，此处不再额外左右缩进 */
+  margin: 0 0 22px;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--nav-text-secondary);
+}
+.nav-section {
+  margin-bottom: 30px;
+}
+.nav-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 14px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--nav-card-border);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--nav-heading);
+}
+.nav-section-title i {
+  color: var(--nav-accent);
+  font-size: 14px;
+}
+
+/* ========== 8. 可访问性 ========== */
+.nav-skip-link {
+  position: absolute;
+  left: -999px;
+  top: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: 2000;
+  padding: 10px 16px;
+  background: var(--nav-accent);
+  color: #fff;
+  border-radius: 0 0 6px 0;
+}
+.nav-skip-link:focus {
+  left: 0;
+  width: auto;
+  height: auto;
+  overflow: visible;
+}
+.nav-card:focus-visible,
+.nav-search:focus-visible,
+.nav-search-clear:focus-visible,
+.nav-theme-toggle:focus-visible,
+.nav-skip-link:focus-visible {
+  outline: 3px solid var(--nav-accent);
+  outline-offset: 2px;
+}
+
+/* ========== 9. 动效：尊重“减少动态效果”系统设置 ========== */
+@media (prefers-reduced-motion: reduce) {
+  .box2,
+  .nav-search,
+  .nav-theme-toggle {
+    transition: none !important;
+  }
+  .box2:hover {
+    transform: none !important;
+  }
+}
+
+/* ========== 10. 筛选状态（配合前端搜索脚本使用） ========== */
+.nav-hidden {
+  display: none !important;
+}
+.nav-no-result {
+  padding: 60px 20px;
+  text-align: center;
+  color: var(--nav-text-secondary);
+  font-size: 14px;
+}
+
+/* ========== 11. 移动端顶栏 ========== */
+/* app.css 在 max-width:768px 下用 .page-container .main-content .navbar.user-info-navbar
+   把整条顶栏隐藏了，会连带藏掉搜索框和主题切换。这里以同等特异性放行，
+   并隐藏其中的汉堡按钮——移动端展开菜单由侧边栏自带的按钮负责，不必重复。 */
+@media screen and (max-width: 768px) {
+  .page-container .main-content .navbar.user-info-navbar {
+    display: block;
+    min-height: 0;
+    padding: 8px 15px;
+    margin: 0 -15px 10px;
+  }
+  .page-container .main-content .navbar.user-info-navbar .user-info-menu {
+    display: none;
+  }
+  .nav-toolbar {
+    width: 100%;
+    gap: 8px;
+  }
+  .nav-search-wrap {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  /* 桌面端是 220px 定宽 + max-width:50vw，窄屏下要改成撑满容器 */
+  .nav-search {
+    width: 100%;
+    max-width: none;
+  }
+}

--- a/src/main/webapp/static/js/common/ajax-object.js
+++ b/src/main/webapp/static/js/common/ajax-object.js
@@ -1,4 +1,20 @@
 (function () {
+	var readCookie = function (name) {
+		var prefix = name + "=";
+		var parts = document.cookie ? document.cookie.split(";") : [];
+		for (var i = 0; i < parts.length; i++) {
+			var part = parts[i].replace(/^\s+/, "");
+			if (part.indexOf(prefix) === 0) {
+				return decodeURIComponent(part.substring(prefix.length));
+			}
+		}
+		return "";
+	};
+
+	window.getCsrfToken = function () {
+		return readCookie("XSRF-TOKEN");
+	};
+
 	var $ax = function (url, success, error) {
 		this.url = url;
 		this.type = "post";
@@ -25,8 +41,11 @@
 		        dataType: this.dataType,
 		        async: this.async,
 		        data: this.data,
-				beforeSend: function(data) {
-					
+				beforeSend: function(xhr) {
+					var token = window.getCsrfToken();
+					if (token) {
+						xhr.setRequestHeader("X-CSRF-TOKEN", token);
+					}
 				},
 		        success: function(data) {
 		        	me.success(data);

--- a/src/main/webapp/static/js/common/web-upload-object.js
+++ b/src/main/webapp/static/js/common/web-upload-object.js
@@ -14,7 +14,7 @@
 		this.uploadBtnId = pictureId + "BtnId";
 		this.uploadPreId = pictureId + "PreId";
 		this.uploadUrl = Feng.ctxPath + '/mgr/upload';
-		this.fileSizeLimit = 100 * 1024 * 1024;
+		this.fileSizeLimit = 5 * 1024 * 1024;
 		this.picWidth = 800;
 		this.picHeight = 800;
         this.uploadBarId = null;
@@ -50,6 +50,9 @@
 				disableGlobalDnd : true,
 				duplicate : true,
 				server : this.uploadUrl,
+				headers : {
+					'X-CSRF-TOKEN' : window.getCsrfToken ? window.getCsrfToken() : ''
+				},
 				fileSingleSizeLimit : this.fileSizeLimit
 			});
 			

--- a/src/main/webapp/static/js/nav.js
+++ b/src/main/webapp/static/js/nav.js
@@ -1,0 +1,385 @@
+/*!
+ * nav.js —— WebStack-Guns 前台首页交互脚本
+ * 纯原生 JS，无依赖（不用 jQuery/构建工具/import-export）。
+ * 以 <script src="/static/js/nav.js" defer> 加载，DOM 已就绪，无需再包 DOMContentLoaded。
+ *
+ * 接管原内联逻辑：
+ *   1 深色模式读写（需与 head 防闪脚本结果一致） 2 搜索筛选(新增)
+ *   3 侧边栏死链修复（原 $(href).offset() 遇不存在锚点会抛错，如线上 #test/#灵感采集）
+ *   4 平滑滚动（原 $("a.smooth").click(...)） 5 滚动高亮 scrollspy(新增) 6 页脚年份
+ *   7 站点图标多级兜底(新增，替代每张卡片内联 onerror)
+ *
+ * 各 initXxx 模块独立、各自 try/catch，互不影响；页面缺元素时静默跳过。
+ */
+(function () {
+  'use strict';
+
+  var THEME_KEY = 'nav-theme';
+
+  // 取出 href 的 hash 并 decode（中文锚点属性里可能是 %E7%81%B5... 编码形式）
+  function getHashId(href) {
+    var i = (href || '').indexOf('#');
+    if (i === -1) return '';
+    var raw = href.slice(i + 1);
+    if (!raw) return '';
+    try {
+      return decodeURIComponent(raw);
+    } catch (e) {
+      return raw;
+    }
+  }
+
+  /* ===================== 1. 深色模式 ===================== */
+  function initTheme() {
+    var root = document.documentElement;
+    var mql = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+
+    function saved() {
+      try {
+        return localStorage.getItem(THEME_KEY);
+      } catch (e) {
+        return null;
+      }
+    }
+
+    function apply(theme) {
+      root.setAttribute('data-theme', theme);
+      var btn = document.getElementById('nav-theme-toggle');
+      if (!btn) return;
+      var icon = btn.querySelector('i');
+      if (icon) {
+        icon.classList.remove('fa-moon-o', 'fa-sun-o');
+        icon.classList.add(theme === 'dark' ? 'fa-sun-o' : 'fa-moon-o');
+      }
+      btn.setAttribute('aria-label', theme === 'dark' ? '切换浅色模式' : '切换深色模式');
+    }
+
+    // 优先级：localStorage > 系统 prefers-color-scheme > 亮色，需与 head 防闪脚本一致
+    var s = saved();
+    apply(s === 'light' || s === 'dark' ? s : ((mql && mql.matches) ? 'dark' : 'light'));
+
+    var toggleBtn = document.getElementById('nav-theme-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', function () {
+        var next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        apply(next);
+        try {
+          localStorage.setItem(THEME_KEY, next);
+        } catch (e) { /* 忽略 */ }
+      });
+    }
+
+    if (mql) {
+      var onSystemChange = function (e) {
+        if (saved() === 'light' || saved() === 'dark') return; // 用户手动设置过不跟随系统
+        apply(e.matches ? 'dark' : 'light');
+      };
+      if (typeof mql.addEventListener === 'function') mql.addEventListener('change', onSystemChange);
+      else if (typeof mql.addListener === 'function') mql.addListener(onSystemChange);
+    }
+  }
+
+  /* ===================== 2. 侧边栏死链修复 ===================== */
+  // 部分 a.smooth 指向不存在的锚点，原 jQuery offset() 会抛错导致后续绑定全部失效。
+  // 这里预先清理死链菜单项；若父级子菜单因此被清空，一并移除父级。
+  function initSidebarDeadLinks() {
+    var menu = document.getElementById('main-menu');
+    if (!menu) return;
+
+    Array.from(menu.querySelectorAll('a.smooth')).forEach(function (a) {
+      var id = getHashId(a.getAttribute('href'));
+      if (!id || document.getElementById(id)) return;
+
+      var li = a.closest ? a.closest('li') : null;
+      if (!li) return;
+
+      console.warn('[nav.js] 侧边栏锚点不存在，已移除菜单项：#' + id);
+
+      var parentUl = li.parentElement;
+      li.remove();
+
+      if (parentUl && parentUl !== menu && parentUl.tagName === 'UL' && parentUl.children.length === 0) {
+        var parentLi = parentUl.parentElement;
+        if (parentLi && parentLi.tagName === 'LI') parentLi.remove();
+      }
+    });
+  }
+
+  /* ===================== 3. 站点搜索 / 筛选 ===================== */
+  function initSearch() {
+    var input = document.getElementById('nav-search');
+    var main = document.getElementById('nav-main');
+    if (!input || !main) return; // 例如 about 页没有搜索框，静默跳过
+
+    var clearBtn = document.getElementById('nav-search-clear');
+    var noResult = document.getElementById('nav-no-result');
+    var menu = document.getElementById('main-menu');
+
+    // 卡片标题/描述/链接不放在 data-* 属性上（避免录入内容含双引号截断属性、
+    // 避免重复注入文本），改为从卡片 DOM 内部读取；抽成函数便于以后替换取数方式。
+    // 所属分类名也纳入检索：站点文本里往往不含分类词（例如没有任何一张卡片
+    // 的标题或描述含「配色」，但存在「在线配色」分类），不带上会搜不出来。
+    function extractCardText(colEl, sectionName) {
+      var titleEl = colEl.querySelector('.xe-user-name');
+      var descEl = colEl.querySelector('.xe-comment p');
+      var linkEl = colEl.querySelector('a.nav-card');
+      var title = titleEl ? (titleEl.textContent || '').trim() : '';
+      var desc = descEl ? (descEl.textContent || '').trim() : '';
+      var url = linkEl ? (linkEl.getAttribute('href') || '').trim() : '';
+      return (title + ' ' + desc + ' ' + url + ' ' + (sectionName || '')).toLowerCase();
+    }
+
+    var sections = Array.from(main.querySelectorAll('.nav-section')).map(function (sectionEl) {
+      var titleEl = sectionEl.querySelector('.nav-section-title');
+      var sectionName = sectionEl.getAttribute('data-section') ||
+        (titleEl ? (titleEl.textContent || '').trim() : '');
+      var cols = Array.from(sectionEl.querySelectorAll('.nav-col')).map(function (colEl) {
+        return { el: colEl, text: extractCardText(colEl, sectionName) };
+      });
+      return { el: sectionEl, cols: cols };
+    });
+
+    // 缓存侧边栏链接 -> 目标分区，供筛选时联动隐藏菜单项
+    var sidebarLinks = menu ? Array.from(menu.querySelectorAll('a.smooth')).map(function (a) {
+      var target = document.getElementById(getHashId(a.getAttribute('href')));
+      return { li: a.closest ? a.closest('li') : null, sectionEl: target ? target.closest('.nav-section') : null };
+    }) : [];
+
+    var debounceTimer = null;
+
+    function applyFilter() {
+      var raw = input.value.trim().toLowerCase();
+      var words = raw ? raw.split(/\s+/) : [];
+      var anyVisible = false;
+
+      sections.forEach(function (section) {
+        var sectionVisible = false;
+        section.cols.forEach(function (col) {
+          var match = words.length === 0 || words.every(function (w) { return col.text.indexOf(w) !== -1; });
+          col.el.classList.toggle('nav-hidden', !match);
+          if (match) {
+            sectionVisible = true;
+            anyVisible = true;
+          }
+        });
+        section.el.classList.toggle('nav-hidden', !sectionVisible);
+      });
+
+      var searching = words.length > 0;
+      sidebarLinks.forEach(function (link) {
+        if (!link.li) return;
+        var hidden = searching && link.sectionEl ? link.sectionEl.classList.contains('nav-hidden') : false;
+        link.li.classList.toggle('nav-hidden', hidden);
+      });
+
+      if (noResult) noResult.hidden = anyVisible;
+      if (clearBtn) clearBtn.hidden = raw.length === 0;
+
+      main.dataset.navSearching = searching ? '1' : ''; // 供 scrollspy 判断是否暂停
+    }
+
+    function scheduleFilter() {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(applyFilter, 120);
+    }
+
+    function resetSearch() {
+      input.value = '';
+      applyFilter();
+    }
+
+    input.addEventListener('input', scheduleFilter);
+
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') resetSearch();
+    });
+
+    if (clearBtn) {
+      clearBtn.addEventListener('click', function () {
+        resetSearch();
+        input.focus();
+      });
+    }
+
+    // / 或 Ctrl/Cmd+K 聚焦搜索框，焦点已在输入类元素中时不拦截
+    document.addEventListener('keydown', function (e) {
+      var t = e.target;
+      var isEditable = !!t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
+      if (isEditable) return;
+
+      if (e.key === '/' || ((e.ctrlKey || e.metaKey) && (e.key === 'k' || e.key === 'K'))) {
+        e.preventDefault();
+        input.focus();
+      }
+    });
+
+    applyFilter(); // 初始化一次，确保按钮/提示状态正确
+  }
+
+  /* ===================== 4. 平滑滚动 ===================== */
+  function initSmoothScroll() {
+    var menu = document.getElementById('main-menu');
+    if (!menu) return;
+
+    var reduceMotion = !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+    var OFFSET = 24; // 顶部预留余量，避免标题被顶栏遮挡
+
+    menu.addEventListener('click', function (e) {
+      var a = e.target && e.target.closest ? e.target.closest('a.smooth') : null;
+      if (!a || !menu.contains(a)) return;
+
+      var id = getHashId(a.getAttribute('href'));
+      var target = id ? document.getElementById(id) : null;
+      if (!target) return; // 目标不存在时安全跳过，不抛错
+
+      e.preventDefault();
+
+      var top = target.getBoundingClientRect().top + window.pageYOffset - OFFSET;
+      window.scrollTo({ top: top, behavior: reduceMotion ? 'auto' : 'smooth' });
+
+      if (window.history && history.replaceState) {
+        history.replaceState(null, '', '#' + encodeURIComponent(id));
+      }
+
+      // 窄屏下点击后收起移动端菜单
+      var sidebar = document.querySelector('.sidebar-menu');
+      if (sidebar) sidebar.classList.remove('mobile-is-visible');
+      menu.classList.remove('mobile-is-visible');
+    });
+  }
+
+  /* ===================== 5. 滚动高亮 scrollspy ===================== */
+  function initScrollSpy() {
+    var main = document.getElementById('nav-main');
+    var menu = document.getElementById('main-menu');
+    if (!main || !menu || !('IntersectionObserver' in window)) return;
+
+    var titles = Array.from(main.querySelectorAll('.nav-section-title'));
+    if (!titles.length) return;
+
+    // 分区 id -> 侧边栏 <li> 映射
+    var linkMap = {};
+    Array.from(menu.querySelectorAll('a.smooth')).forEach(function (a) {
+      var id = getHashId(a.getAttribute('href'));
+      var li = a.closest ? a.closest('li') : null;
+      if (id && li) linkMap[id] = li;
+    });
+
+    var allLis = Array.from(menu.querySelectorAll('li'));
+
+    function setActive(id) {
+      allLis.forEach(function (li) { li.classList.remove('active'); });
+
+      var li = linkMap[id];
+      if (!li) return;
+      li.classList.add('active');
+
+      // 父级菜单同步高亮并展开
+      var node = li.parentElement;
+      while (node && node !== menu && node.tagName === 'UL') {
+        var parentLi = node.parentElement;
+        if (!parentLi || parentLi.tagName !== 'LI') break;
+        parentLi.classList.add('active');
+        parentLi.classList.add('expanded');
+        node = parentLi.parentElement;
+      }
+    }
+
+    var visible = new Map();
+
+    var observer = new IntersectionObserver(function (entries) {
+      if (main.dataset.navSearching) return; // 搜索中暂停高亮，避免乱跳
+
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) visible.set(entry.target, entry.boundingClientRect.top);
+        else visible.delete(entry.target);
+      });
+      if (visible.size === 0) return;
+
+      var topMost = null;
+      var topMostPos = Infinity;
+      visible.forEach(function (pos, el) {
+        if (pos < topMostPos) {
+          topMostPos = pos;
+          topMost = el;
+        }
+      });
+      if (topMost && topMost.id) setActive(topMost.id);
+    }, { root: null, rootMargin: '-72px 0px -70% 0px', threshold: 0 });
+
+    titles.forEach(function (title) { observer.observe(title); });
+  }
+
+  /* ===================== 6. 页脚年份 ===================== */
+  function initFooterYear() {
+    var el = document.getElementById('nav-year');
+    if (el) el.textContent = String(new Date().getFullYear());
+  }
+
+  /* ===================== 启动 ===================== */
+  /* ===================== 7. 站点图标兜底 ===================== */
+  // 图标优先走 /static/tmp/（随仓库发布、可缓存、无重定向），取不到再退回
+  // /kaptcha/（后台新上传的图只在上传目录里），最后退到本地占位图。
+  // 放在 JS 里而不是每个 <img> 内联 onerror：196 张卡片可省下约 17KB HTML。
+  var ICON_STATIC = '/static/tmp/';
+  var ICON_UPLOAD = '/kaptcha/';
+  var ICON_PLACEHOLDER = '/static/img/github.png';
+
+  function nextIconSrc(img) {
+    var src = img.getAttribute('src') || '';
+    var name = src.slice(src.lastIndexOf('/') + 1);
+    if (!name) return null;
+    if (src.indexOf(ICON_STATIC) !== -1) return ICON_UPLOAD + name;
+    if (src.indexOf(ICON_UPLOAD) !== -1) return ICON_PLACEHOLDER;
+    return null; // 已是占位图或站外图（如 about 页头像自带 onerror），不再接管
+  }
+
+  function fallbackIcon(img) {
+    if (!img || img.tagName !== 'IMG' || !img.classList.contains('nav-card-icon')) return;
+    var next = nextIconSrc(img);
+    if (next) img.setAttribute('src', next);
+  }
+
+  function initIconFallback() {
+    // error 事件不冒泡，只能在捕获阶段监听
+    window.addEventListener('error', function (e) {
+      fallbackIcon(e.target);
+    }, true);
+
+    // 兜底扫描：defer 脚本执行前可能已有图片加载失败，错过了上面的监听
+    window.addEventListener('load', function () {
+      Array.prototype.forEach.call(
+        document.querySelectorAll('img.nav-card-icon'),
+        function (img) {
+          if (img.complete && img.naturalWidth === 0) fallbackIcon(img);
+        }
+      );
+    });
+  }
+
+  function safeRun(fn) {
+    try {
+      fn();
+    } catch (err) {
+      if (window.console && console.error) console.error('[nav.js] 模块执行出错：' + (fn && fn.name), err);
+    }
+  }
+
+  function boot() {
+    safeRun(initIconFallback); // 需最早注册，尽量赶在图片加载失败之前
+    safeRun(initTheme);
+    safeRun(initSidebarDeadLinks);
+    safeRun(initSearch);
+    safeRun(initSmoothScroll);
+    safeRun(initScrollSpy);
+    safeRun(initFooterYear);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+
+  window.NavUI = { version: '1.0.0' }; // 唯一暴露的全局命名空间
+})();

--- a/src/test/java/com/jsnjfz/manage/core/security/CsrfFilterTest.java
+++ b/src/test/java/com/jsnjfz/manage/core/security/CsrfFilterTest.java
@@ -1,0 +1,42 @@
+package com.jsnjfz.manage.core.security;
+
+import com.jsnjfz.manage.config.properties.GunsProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.http.Cookie;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class CsrfFilterTest {
+
+    private final CsrfFilter filter = new CsrfFilter(new GunsProperties());
+
+    @Test
+    void issuesTokenAndRequiresItForPost() throws Exception {
+        MockHttpServletRequest get = new MockHttpServletRequest("GET", "/login");
+        MockHttpServletResponse getResponse = new MockHttpServletResponse();
+        filter.doFilter(get, getResponse, new MockFilterChain());
+        String token = (String) get.getAttribute(CsrfFilter.REQUEST_ATTRIBUTE);
+
+        assertNotNull(token);
+        assertNotNull(getResponse.getHeader("Set-Cookie"));
+
+        MockHttpServletRequest rejected = new MockHttpServletRequest("POST", "/login");
+        rejected.setSession(get.getSession());
+        MockHttpServletResponse rejectedResponse = new MockHttpServletResponse();
+        filter.doFilter(rejected, rejectedResponse, new MockFilterChain());
+        assertEquals(403, rejectedResponse.getStatus());
+
+        MockHttpServletRequest accepted = new MockHttpServletRequest("POST", "/login");
+        accepted.setSession(get.getSession());
+        accepted.setCookies(new Cookie(CsrfFilter.COOKIE_NAME, token));
+        accepted.addHeader(CsrfFilter.HEADER_NAME, token);
+        MockHttpServletResponse acceptedResponse = new MockHttpServletResponse();
+        filter.doFilter(accepted, acceptedResponse, new MockFilterChain());
+        assertEquals(200, acceptedResponse.getStatus());
+    }
+}

--- a/src/test/java/com/jsnjfz/manage/core/security/LoginAttemptServiceTest.java
+++ b/src/test/java/com/jsnjfz/manage/core/security/LoginAttemptServiceTest.java
@@ -1,0 +1,25 @@
+package com.jsnjfz.manage.core.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LoginAttemptServiceTest {
+
+    @Test
+    void blocksAfterFiveFailuresAndResetsAfterSuccess() {
+        LoginAttemptService service = new LoginAttemptService();
+        String address = "127.0.0.1";
+        String username = "admin";
+
+        for (int i = 0; i < 5; i++) {
+            assertTrue(service.isAllowed(address, username));
+            service.recordFailure(address, username);
+        }
+        assertFalse(service.isAllowed(address, username));
+
+        service.reset(address, username);
+        assertTrue(service.isAllowed(address, username));
+    }
+}

--- a/src/test/java/com/jsnjfz/manage/core/security/PasswordServiceTest.java
+++ b/src/test/java/com/jsnjfz/manage/core/security/PasswordServiceTest.java
@@ -1,0 +1,28 @@
+package com.jsnjfz.manage.core.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PasswordServiceTest {
+
+    private final PasswordService passwordService = new PasswordService();
+
+    @Test
+    void supportsModernPasswordHashes() {
+        String encoded = passwordService.encode("a-secure-password");
+
+        assertTrue(passwordService.isModern(encoded));
+        assertTrue(passwordService.matches("a-secure-password", encoded, null));
+        assertFalse(passwordService.matches("wrong-password", encoded, null));
+    }
+
+    @Test
+    void acceptsTheLegacyAdminPasswordForMigration() {
+        assertTrue(passwordService.matchesOrBurn(
+                "111111", "ecfadcde9305f8891bcfe5a1e28c253e", "8pgby"));
+        assertFalse(passwordService.matchesOrBurn(
+                "111112", "ecfadcde9305f8891bcfe5a1e28c253e", "8pgby"));
+    }
+}

--- a/src/test/java/com/jsnjfz/manage/core/security/RichTextSanitizerTest.java
+++ b/src/test/java/com/jsnjfz/manage/core/security/RichTextSanitizerTest.java
@@ -1,0 +1,24 @@
+package com.jsnjfz.manage.core.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RichTextSanitizerTest {
+
+    private final RichTextSanitizer sanitizer = new RichTextSanitizer();
+
+    @Test
+    void removesExecutableMarkupAndKeepsBasicFormatting() {
+        String sanitized = sanitizer.sanitize(
+                "<p><b>公告</b><img src=x onerror=alert(1)>"
+                        + "<a href=\"javascript:alert(1)\">link</a><script>alert(1)</script></p>");
+
+        assertTrue(sanitized.contains("<p>"));
+        assertTrue(sanitized.contains("<b>公告</b>"));
+        assertFalse(sanitized.toLowerCase().contains("script"));
+        assertFalse(sanitized.toLowerCase().contains("onerror"));
+        assertFalse(sanitized.toLowerCase().contains("javascript:"));
+    }
+}

--- a/src/test/java/com/jsnjfz/manage/core/util/JwtTokenUtilTest.java
+++ b/src/test/java/com/jsnjfz/manage/core/util/JwtTokenUtilTest.java
@@ -1,0 +1,40 @@
+package com.jsnjfz.manage.core.util;
+
+import com.jsnjfz.manage.config.properties.GunsProperties;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JwtTokenUtilTest {
+
+    @Test
+    void signsAndValidatesWithConfiguredKey() {
+        JwtTokenUtil tokenUtil = new JwtTokenUtil(propertiesWithKey((byte) 1));
+        String token = tokenUtil.generateToken("1");
+
+        tokenUtil.parseToken(token);
+        assertEquals("1", tokenUtil.getUsernameFromToken(token));
+        assertThrows(JwtException.class,
+                () -> new JwtTokenUtil(propertiesWithKey((byte) 2)).parseToken(token));
+    }
+
+    @Test
+    void rejectsShortConfiguredKey() {
+        GunsProperties properties = new GunsProperties();
+        properties.setJwtSecret(Base64.getEncoder().encodeToString(new byte[32]));
+
+        assertThrows(IllegalArgumentException.class, () -> new JwtTokenUtil(properties));
+    }
+
+    private GunsProperties propertiesWithKey(byte fill) {
+        byte[] key = new byte[64];
+        java.util.Arrays.fill(key, fill);
+        GunsProperties properties = new GunsProperties();
+        properties.setJwtSecret(Base64.getEncoder().encodeToString(key));
+        return properties;
+    }
+}

--- a/src/test/java/com/jsnjfz/manage/modular/system/model/UserSensitiveDataTest.java
+++ b/src/test/java/com/jsnjfz/manage/modular/system/model/UserSensitiveDataTest.java
@@ -1,0 +1,20 @@
+package com.jsnjfz.manage.modular.system.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class UserSensitiveDataTest {
+
+    @Test
+    void doesNotExposePasswordMaterialInToString() {
+        User user = new User();
+        user.setPassword("password-material");
+        user.setSalt("salt-material");
+
+        String text = user.toString();
+
+        assertFalse(text.contains("password-material"));
+        assertFalse(text.contains("salt-material"));
+    }
+}


### PR DESCRIPTION
## What changed

- Upgrade the JDK 8-compatible Spring Boot, Spring Framework, Tomcat, Jackson, MySQL, Shiro and supporting dependency lines.
- Add a Maven Enforcer gate that requires JDK 8.
- Externalize database credentials and JWT/remember-me keys; disable Swagger and Druid by default.
- Prevent user password/salt values and MyBatis query results from being written to application logs.
- Migrate legacy MD5 passwords to PBKDF2 after successful login.
- Add login throttling, authenticated-session rotation, REST user-status validation, CSRF protection and browser security headers.
- Sanitize rich-text content and harden image upload/read paths with decoding, re-encoding, size/pixel limits and normalized paths.
- Add the existing-schema migration script, security notes and focused regression tests.
- Preserve the current navigation/UI refresh included in the working tree.

## Why

The repository depended on old framework versions, had mixed Shiro coordinates, embedded weak/default secrets, legacy password hashing and missing request/upload protections. Some automatic Snyk upgrades also require Java 11, which conflicts with the project's mandatory JDK 8 runtime. This change uses the newest tested JDK 8-compatible lines and documents or mitigates the remaining version-level advisories.

## Impact

Database credentials must now be supplied through environment variables. Local development still defaults to `127.0.0.1:8000`; Swagger and Druid require explicit opt-in. Legacy users are migrated transparently after a valid login.

## Validation

- Zulu JDK `1.8.0_492`
- `mvn clean verify`: 8 tests passed
- Maven Enforcer JDK 8 rule passed
- MySQL 8.4 on `127.0.0.1:3306`, 13-table schema and administrator login verified
- HTTP checks covered login, session rotation, CSRF positive/negative cases, REST token positive/negative cases, invalid upload handling, security headers, and disabled Swagger/Druid endpoints
- OSV Maven dependency scan reduced unique advisories from 208 to 22; remaining conditional findings are documented in `SECURITY.md`
- Credential-pattern scan and `git diff --check` passed
- Live authentication request confirmed that SQL parameters and credential fields are no longer printed to the console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive navigation with search, dark mode, accessibility improvements, and automatic footer year updates.
  * Added CSRF protection, login attempt limiting, stronger password handling, secure cookies, and browser security headers.
  * Added safer image uploads with file, size, and content validation.
  * Added environment-based configuration for database credentials and security keys.

* **Bug Fixes**
  * Improved JWT validation and blocked inactive or invalid accounts.
  * Corrected dynamic filtering and upload error responses.

* **Documentation**
  * Expanded setup, database migration, deployment, compatibility, and security guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->